### PR TITLE
feat: add ErrorBoundary and ProtectedRoute components (closes #4)

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -31,6 +31,8 @@ import type { ApiClient } from '../api/apiClient'
 import { ApiError } from '../api/apiClient'
 import { createAuthApi } from './authApi'
 import type { AuthApiConfig, LoginResponse } from './authApi'
+import { createProtectedRoute } from '../components/ProtectedRoute'
+import type { ProtectedRouteProps } from '../components/ProtectedRoute'
 
 /** Verdier eksponert av useAuth() */
 export interface AuthContextValue<TUser> {
@@ -69,6 +71,7 @@ export interface AuthProviderConfig<TUser> extends AuthApiConfig {
 export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
   AuthProvider: React.FC<{ children: ReactNode }>
   useAuth: () => AuthContextValue<TUser>
+  ProtectedRoute: React.FC<ProtectedRouteProps<TUser>>
 } {
   const {
     apiClient,
@@ -149,5 +152,7 @@ export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
     return context
   }
 
-  return { AuthProvider, useAuth }
+  const ProtectedRoute = createProtectedRoute<TUser>(useAuth)
+
+  return { AuthProvider, useAuth, ProtectedRoute }
 }

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,95 @@
+/// <reference types="vitest/config" />
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ErrorBoundary } from './ErrorBoundary'
+
+// Komponent som kaster feil for testing
+function ThrowingComponent({ error }: { error?: Error }) {
+  if (error) throw error
+  return <div>Alt fungerer</div>
+}
+
+describe('ErrorBoundary', () => {
+  // Undertryck console.error fra React under ErrorBoundary-testing
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('rendrer children når ingen feil oppstår', () => {
+    render(
+      <ErrorBoundary fallback={<p>Feil</p>}>
+        <p>Innhold</p>
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('Innhold')).toBeDefined()
+  })
+
+  it('viser fallback ReactNode når en feil kastes', () => {
+    render(
+      <ErrorBoundary fallback={<p>Noe gikk galt</p>}>
+        <ThrowingComponent error={new Error('Testfeil')} />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('Noe gikk galt')).toBeDefined()
+  })
+
+  it('viser fallback render-funksjon med error og reset', () => {
+    render(
+      <ErrorBoundary
+        fallback={(error, reset) => (
+          <div>
+            <p>Feil: {error.message}</p>
+            <button onClick={reset}>Prøv igjen</button>
+          </div>
+        )}
+      >
+        <ThrowingComponent error={new Error('Render-feil')} />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('Feil: Render-feil')).toBeDefined()
+    expect(screen.getByText('Prøv igjen')).toBeDefined()
+  })
+
+  it('kaller onError callback med error og errorInfo', () => {
+    const onError = vi.fn()
+    render(
+      <ErrorBoundary fallback={<p>Feil</p>} onError={onError}>
+        <ThrowingComponent error={new Error('Callback-feil')} />
+      </ErrorBoundary>
+    )
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error)
+    expect(onError.mock.calls[0][0].message).toBe('Callback-feil')
+    // errorInfo skal ha componentStack
+    expect(onError.mock.calls[0][1]).toHaveProperty('componentStack')
+  })
+
+  it('bruker standard fallback-melding uten fallback-prop', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent error={new Error('Uventet feil')} />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('Noe gikk galt')).toBeDefined()
+    expect(screen.getByText('Last inn siden på nytt')).toBeDefined()
+  })
+
+  it('setter className på wrapper-elementet', () => {
+    const { container } = render(
+      <ErrorBoundary className="min-error-klasse" fallback={<p>Feil</p>}>
+        <ThrowingComponent error={new Error('Klasse-test')} />
+      </ErrorBoundary>
+    )
+    const wrapper = container.firstElementChild
+    expect(wrapper?.className).toBe('min-error-klasse')
+  })
+})

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,104 @@
+/**
+ * Styling-agnostisk ErrorBoundary-komponent.
+ *
+ * Fanger ubehandlede feil i React-komponenttreet og viser en
+ * konfigurerbar fallback-UI. Støtter både enkel ReactNode-fallback
+ * og render-funksjon med error + reset-callback.
+ *
+ * @example
+ * ```tsx
+ * // Enkel bruk med standard fallback
+ * <ErrorBoundary>
+ *   <App />
+ * </ErrorBoundary>
+ *
+ * // Med custom render-funksjon
+ * <ErrorBoundary
+ *   fallback={(error, reset) => (
+ *     <div>
+ *       <p>Feil: {error.message}</p>
+ *       <button onClick={reset}>Prøv igjen</button>
+ *     </div>
+ *   )}
+ *   onError={(error, info) => loggTilServer(error)}
+ * >
+ *   <App />
+ * </ErrorBoundary>
+ * ```
+ */
+
+import { Component } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+
+/** Props for ErrorBoundary-komponenten */
+export interface ErrorBoundaryProps {
+  /** Barn som beskyttes av error boundary */
+  children: ReactNode
+  /** CSS-klasse på wrapper-elementet ved feil */
+  className?: string
+  /** Fallback-UI: ReactNode eller render-funksjon med (error, reset) */
+  fallback?: ReactNode | ((error: Error, reset: () => void) => ReactNode)
+  /** Callback når feil fanges — for logging/rapportering */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void
+}
+
+interface ErrorBoundaryState {
+  error: Error | null
+}
+
+/**
+ * Error Boundary som fanger ubehandlede feil i komponenttreet.
+ *
+ * Class component er påkrevd — React har ingen hook-ekvivalent
+ * for getDerivedStateFromError/componentDidCatch.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.props.onError?.(error, errorInfo)
+  }
+
+  /** Nullstill feilstatus — lar brukeren prøve å rendre på nytt */
+  private reset = () => {
+    this.setState({ error: null })
+  }
+
+  render() {
+    const { error } = this.state
+    const { children, className, fallback } = this.props
+
+    if (error) {
+      let content: ReactNode
+
+      if (typeof fallback === 'function') {
+        content = fallback(error, this.reset)
+      } else if (fallback !== undefined) {
+        content = fallback
+      } else {
+        // Standard fallback-melding
+        content = (
+          <>
+            <p>Noe gikk galt</p>
+            <p>Last inn siden på nytt</p>
+          </>
+        )
+      }
+
+      if (className) {
+        return <div className={className}>{content}</div>
+      }
+
+      return <>{content}</>
+    }
+
+    return children
+  }
+}

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,201 @@
+/// <reference types="vitest/config" />
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { createProtectedRoute } from './ProtectedRoute'
+import type { AuthContextValue } from '../auth/AuthContext'
+
+// Hjelpefunksjon: lag mock useAuth med gitte verdier
+function createMockUseAuth<TUser>(overrides: Partial<AuthContextValue<TUser>> = {}) {
+  const defaults: AuthContextValue<TUser> = {
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    refreshUser: vi.fn(),
+  }
+  return () => ({ ...defaults, ...overrides })
+}
+
+interface TestUser {
+  id: number
+  email: string
+  role: string
+}
+
+describe('createProtectedRoute', () => {
+  it('redirecter til loginPath når bruker ikke er autentisert', () => {
+    const useAuth = createMockUseAuth<TestUser>({ isAuthenticated: false })
+    const ProtectedRoute = createProtectedRoute(useAuth)
+
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route path="/logg-inn" element={<p>Innloggingsside</p>} />
+          <Route element={<ProtectedRoute loginPath="/logg-inn" />}>
+            <Route path="/dashboard" element={<p>Dashboard</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Innloggingsside')).toBeDefined()
+  })
+
+  it('viser children/outlet når bruker er autentisert', () => {
+    const useAuth = createMockUseAuth<TestUser>({
+      isAuthenticated: true,
+      user: { id: 1, email: 'test@test.no', role: 'user' },
+    })
+    const ProtectedRoute = createProtectedRoute(useAuth)
+
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route path="/logg-inn" element={<p>Innloggingsside</p>} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="/dashboard" element={<p>Dashboard</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Dashboard')).toBeDefined()
+  })
+
+  it('viser loadingComponent når isLoading er true', () => {
+    const useAuth = createMockUseAuth<TestUser>({ isLoading: true })
+    const ProtectedRoute = createProtectedRoute(useAuth)
+
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route element={<ProtectedRoute loadingComponent={<p>Laster...</p>} />}>
+            <Route path="/dashboard" element={<p>Dashboard</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Laster...')).toBeDefined()
+  })
+
+  it('returnerer null som standard ved isLoading uten loadingComponent', () => {
+    const useAuth = createMockUseAuth<TestUser>({ isLoading: true })
+    const ProtectedRoute = createProtectedRoute(useAuth)
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/dashboard" element={<p>Dashboard</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(container.textContent).toBe('')
+  })
+
+  it('redirecter med roleCheck som avviser bruker', () => {
+    const useAuth = createMockUseAuth<TestUser>({
+      isAuthenticated: true,
+      user: { id: 1, email: 'test@test.no', role: 'user' },
+    })
+    const ProtectedRoute = createProtectedRoute(useAuth)
+
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <Routes>
+          <Route path="/logg-inn" element={<p>Innloggingsside</p>} />
+          <Route path="/ingen-tilgang" element={<p>Ingen tilgang</p>} />
+          <Route
+            element={
+              <ProtectedRoute
+                loginPath="/logg-inn"
+                roleCheck={(user) => user.role === 'admin'}
+                unauthorizedPath="/ingen-tilgang"
+              />
+            }
+          >
+            <Route path="/admin" element={<p>Admin-panel</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Ingen tilgang')).toBeDefined()
+  })
+
+  it('viser innhold når roleCheck godkjenner bruker', () => {
+    const useAuth = createMockUseAuth<TestUser>({
+      isAuthenticated: true,
+      user: { id: 1, email: 'admin@test.no', role: 'admin' },
+    })
+    const ProtectedRoute = createProtectedRoute(useAuth)
+
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <Routes>
+          <Route
+            element={
+              <ProtectedRoute roleCheck={(user) => user.role === 'admin'} />
+            }
+          >
+            <Route path="/admin" element={<p>Admin-panel</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Admin-panel')).toBeDefined()
+  })
+
+  it('bruker standard loginPath /logg-inn', () => {
+    const useAuth = createMockUseAuth<TestUser>({ isAuthenticated: false })
+    const ProtectedRoute = createProtectedRoute(useAuth)
+
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route path="/logg-inn" element={<p>Standard innlogging</p>} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="/dashboard" element={<p>Dashboard</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Standard innlogging')).toBeDefined()
+  })
+
+  it('redirecter til loginPath ved feilet roleCheck uten unauthorizedPath', () => {
+    const useAuth = createMockUseAuth<TestUser>({
+      isAuthenticated: true,
+      user: { id: 1, email: 'test@test.no', role: 'user' },
+    })
+    const ProtectedRoute = createProtectedRoute(useAuth)
+
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <Routes>
+          <Route path="/logg-inn" element={<p>Innlogging</p>} />
+          <Route
+            element={
+              <ProtectedRoute roleCheck={(user) => user.role === 'admin'} />
+            }
+          >
+            <Route path="/admin" element={<p>Admin</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Innlogging')).toBeDefined()
+  })
+})

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,73 @@
+/**
+ * Konfigurerbar ProtectedRoute-komponent for rutebeskyttelse.
+ *
+ * Factory-funksjon som tar en useAuth-hook og returnerer en
+ * ProtectedRoute-komponent bundet til den spesifikke auth-konteksten.
+ *
+ * @example
+ * ```tsx
+ * const { AuthProvider, useAuth } = createAuthProvider<MyUser>({...})
+ * const ProtectedRoute = createProtectedRoute(useAuth)
+ *
+ * // Som layout-route med Outlet:
+ * <Route element={<ProtectedRoute />}>
+ *   <Route path="/dashboard" element={<Dashboard />} />
+ * </Route>
+ *
+ * // Med rollesjekk:
+ * <Route element={<ProtectedRoute roleCheck={(u) => u.role === 'admin'} />}>
+ *   <Route path="/admin" element={<Admin />} />
+ * </Route>
+ * ```
+ */
+
+import type { ReactNode } from 'react'
+import { Navigate, Outlet } from 'react-router-dom'
+import type { AuthContextValue } from '../auth/AuthContext'
+
+/** Props for ProtectedRoute-komponenten */
+export interface ProtectedRouteProps<TUser> {
+  /** Sti til innloggingsside (default: '/logg-inn') */
+  loginPath?: string
+  /** Valgfri rollesjekk — returnerer true hvis bruker har tilgang */
+  roleCheck?: (user: TUser) => boolean
+  /** Redirect-sti ved feilet rollesjekk (default: loginPath) */
+  unauthorizedPath?: string
+  /** Komponent som vises under lasting */
+  loadingComponent?: ReactNode
+}
+
+/**
+ * Opprett en ProtectedRoute-komponent bundet til en spesifikk useAuth-hook.
+ *
+ * @param useAuth - useAuth-hook fra createAuthProvider()
+ * @returns ProtectedRoute React-komponent
+ */
+export function createProtectedRoute<TUser>(
+  useAuth: () => AuthContextValue<TUser>
+): React.FC<ProtectedRouteProps<TUser>> {
+  function ProtectedRoute({
+    loginPath = '/logg-inn',
+    roleCheck,
+    unauthorizedPath,
+    loadingComponent,
+  }: ProtectedRouteProps<TUser>) {
+    const { isAuthenticated, isLoading, user } = useAuth()
+
+    if (isLoading) {
+      return <>{loadingComponent ?? null}</>
+    }
+
+    if (!isAuthenticated) {
+      return <Navigate to={loginPath} replace />
+    }
+
+    if (roleCheck && user && !roleCheck(user)) {
+      return <Navigate to={unauthorizedPath ?? loginPath} replace />
+    }
+
+    return <Outlet />
+  }
+
+  return ProtectedRoute
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,9 @@ export { createAuthProvider } from './auth/AuthContext'
 export type { AuthContextValue, AuthProviderConfig } from './auth/AuthContext'
 export { createAuthApi } from './auth/authApi'
 export type { AuthApi, AuthApiConfig, LoginResponse } from './auth/authApi'
+
+// Komponenter
+export { ErrorBoundary } from './components/ErrorBoundary'
+export type { ErrorBoundaryProps } from './components/ErrorBoundary'
+export { createProtectedRoute } from './components/ProtectedRoute'
+export type { ProtectedRouteProps } from './components/ProtectedRoute'


### PR DESCRIPTION
Fixes #4

## Endringer

- **ErrorBoundary**: Styling-agnostisk class component med:
  - `fallback`: ReactNode eller render-funksjon `(error, reset) => ReactNode`
  - `onError`: callback for logging/rapportering
  - `className`: valgfri wrapper-klasse
  - Standard fallback-melding hvis ingen fallback angis
  
- **ProtectedRoute** via `createProtectedRoute(useAuth)`:
  - `loginPath`: konfigurerbar (default `/logg-inn`)
  - `roleCheck`: valgfri callback for rollebasert tilgang
  - `unauthorizedPath`: separat redirect ved feilet rollesjekk
  - `loadingComponent`: valgfri loading-UI
  - Bruker `<Outlet>` for layout-route-mønsteret

- **createAuthProvider** returnerer nå også `ProtectedRoute` for enkel bruk

## Tester (14 nye)

- ErrorBoundary: rendrer children, fanger feil, viser fallback, kaller onError, standard melding, className
- ProtectedRoute: redirect uautentisert, viser innhold autentisert, loading, roleCheck avvis/godkjenn, standard loginPath, fallback til loginPath

🤖 Generated with [Claude Code](https://claude.com/claude-code)