### PR TITLE
feat: add Norwegian formatters (partial #5)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,3 +25,13 @@ export { ErrorBoundary } from './components/ErrorBoundary'
 export type { ErrorBoundaryProps } from './components/ErrorBoundary'
 export { createProtectedRoute } from './components/ProtectedRoute'
 export type { ProtectedRouteProps } from './components/ProtectedRoute'
+
+// Formatters
+export {
+  formatCurrency,
+  formatDate,
+  formatDateTime,
+  formatNumber,
+  formatFileSize,
+  relativeTime
+} from './lib/formatters'

--- a/src/lib/__tests__/formatters.test.ts
+++ b/src/lib/__tests__/formatters.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  formatCurrency,
+  formatDate,
+  formatDateTime,
+  formatNumber,
+  formatFileSize,
+  relativeTime
+} from '../formatters'
+
+describe('formatCurrency', () => {
+  it('formaterer positive beloep i NOK', () => {
+    const result = formatCurrency(1234.5)
+    // nb-NO: "kr 1 234,50" (kan variere med non-breaking spaces)
+    expect(result).toMatch(/kr/)
+    expect(result).toMatch(/1\s?234,50/)
+  })
+
+  it('formaterer 0', () => {
+    const result = formatCurrency(0)
+    expect(result).toMatch(/kr/)
+    expect(result).toMatch(/0,00/)
+  })
+
+  it('formaterer negative beloep', () => {
+    const result = formatCurrency(-500)
+    expect(result).toMatch(/500,00/)
+    expect(result).toMatch(/kr/)
+  })
+
+  it('returnerer tankestrek for NaN', () => {
+    expect(formatCurrency(NaN)).toBe('\u2013')
+  })
+
+  it('returnerer tankestrek for Infinity', () => {
+    expect(formatCurrency(Infinity)).toBe('\u2013')
+  })
+})
+
+describe('formatDate', () => {
+  it('formaterer ISO-streng til dd.MM.yyyy', () => {
+    expect(formatDate('2026-04-08')).toBe('08.04.2026')
+  })
+
+  it('formaterer Date-objekt', () => {
+    const date = new Date(2026, 3, 8) // april = 3 (0-indeksert)
+    expect(formatDate(date)).toBe('08.04.2026')
+  })
+
+  it('returnerer tankestrek for ugyldig dato', () => {
+    expect(formatDate('ugyldig')).toBe('\u2013')
+  })
+})
+
+describe('formatDateTime', () => {
+  it('formaterer dato med klokkeslett', () => {
+    const date = new Date(2026, 3, 8, 14, 30)
+    const result = formatDateTime(date)
+    expect(result).toMatch(/08\.04\.2026/)
+    expect(result).toMatch(/14:30/)
+  })
+
+  it('returnerer tankestrek for ugyldig dato', () => {
+    expect(formatDateTime('ugyldig')).toBe('\u2013')
+  })
+})
+
+describe('formatNumber', () => {
+  it('formaterer tall med norsk tusenskilletegn', () => {
+    const result = formatNumber(1234567)
+    // nb-NO bruker mellomrom som tusenskilletegn
+    expect(result).toMatch(/1\s?234\s?567/)
+  })
+
+  it('formaterer tall med spesifiserte desimaler', () => {
+    const result = formatNumber(1234.5, 2)
+    expect(result).toMatch(/1\s?234,50/)
+  })
+
+  it('formaterer tall med 0 desimaler', () => {
+    const result = formatNumber(1234.567, 0)
+    expect(result).toMatch(/1\s?235/) // avrundet
+  })
+
+  it('returnerer tankestrek for NaN', () => {
+    expect(formatNumber(NaN)).toBe('\u2013')
+  })
+})
+
+describe('formatFileSize', () => {
+  it('formaterer 0 bytes', () => {
+    expect(formatFileSize(0)).toBe('0 B')
+  })
+
+  it('formaterer bytes', () => {
+    expect(formatFileSize(500)).toBe('500 B')
+  })
+
+  it('formaterer kilobytes', () => {
+    const result = formatFileSize(1536)
+    expect(result).toMatch(/1,5\s?KB/)
+  })
+
+  it('formaterer megabytes', () => {
+    const result = formatFileSize(1048576)
+    expect(result).toMatch(/1,0\s?MB/)
+  })
+
+  it('formaterer gigabytes', () => {
+    const result = formatFileSize(1073741824)
+    expect(result).toMatch(/1,0\s?GB/)
+  })
+
+  it('returnerer tankestrek for negative verdier', () => {
+    expect(formatFileSize(-1)).toBe('\u2013')
+  })
+
+  it('returnerer tankestrek for NaN', () => {
+    expect(formatFileSize(NaN)).toBe('\u2013')
+  })
+})
+
+describe('relativeTime', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('viser "1 time siden" for 1 time', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-08T12:00:00'))
+    const oneHourAgo = new Date('2026-04-08T11:00:00')
+    const result = relativeTime(oneHourAgo)
+    expect(result).toMatch(/1 time siden/)
+  })
+
+  it('viser minutter for nylige hendelser', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-08T12:00:00'))
+    const fiveMinAgo = new Date('2026-04-08T11:55:00')
+    const result = relativeTime(fiveMinAgo)
+    expect(result).toMatch(/5 minutter siden/)
+  })
+
+  it('viser dager for eldre hendelser', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-08T12:00:00'))
+    const threeDaysAgo = new Date('2026-04-05T12:00:00')
+    const result = relativeTime(threeDaysAgo)
+    expect(result).toMatch(/3 d(ager|øgn) siden/)
+  })
+
+  it('haandterer fremtidige datoer', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-08T12:00:00'))
+    const tomorrow = new Date('2026-04-09T12:00:00')
+    const result = relativeTime(tomorrow)
+    expect(result).toMatch(/i morgen|om 1 dag/)
+  })
+
+  it('returnerer tankestrek for ugyldig dato', () => {
+    expect(relativeTime('ugyldig')).toBe('\u2013')
+  })
+})

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,0 +1,92 @@
+/**
+ * Norske formatters for dato, valuta, tall, filstørrelse og relativ tid.
+ * Bruker nb-NO locale via Intl API-er.
+ */
+
+const LOCALE = 'nb-NO'
+const DASH = '\u2013' // tankestrek (–)
+
+// Lazy-initialiserte Intl-formatters for ytelse
+let currencyFmt: Intl.NumberFormat
+let dateFmt: Intl.DateTimeFormat
+let dateTimeFmt: Intl.DateTimeFormat
+let relativeFmt: Intl.RelativeTimeFormat
+
+/** Konverterer string | Date til Date, eller null ved ugyldig input */
+function toDate(input: string | Date): Date | null {
+  const d = input instanceof Date ? input : new Date(input)
+  return isNaN(d.getTime()) ? null : d
+}
+
+/** Formaterer beløp i NOK: "kr 1 234,50" */
+export function formatCurrency(amount: number): string {
+  if (!isFinite(amount)) return DASH
+  currencyFmt ??= new Intl.NumberFormat(LOCALE, { style: 'currency', currency: 'NOK' })
+  return currencyFmt.format(amount)
+}
+
+/** Formaterer dato: "08.04.2026" */
+export function formatDate(date: string | Date): string {
+  const d = toDate(date)
+  if (!d) return DASH
+  dateFmt ??= new Intl.DateTimeFormat(LOCALE, { day: '2-digit', month: '2-digit', year: 'numeric' })
+  return dateFmt.format(d)
+}
+
+/** Formaterer dato med klokkeslett: "08.04.2026, 14:30" */
+export function formatDateTime(date: string | Date): string {
+  const d = toDate(date)
+  if (!d) return DASH
+  dateTimeFmt ??= new Intl.DateTimeFormat(LOCALE, {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit'
+  })
+  return dateTimeFmt.format(d)
+}
+
+/** Formaterer tall med norsk tusenskilletegn og valgfritt antall desimaler */
+export function formatNumber(num: number, decimals?: number): string {
+  if (!isFinite(num)) return DASH
+  const fmt = new Intl.NumberFormat(LOCALE, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals
+  })
+  return fmt.format(num)
+}
+
+/** Formaterer filstørrelse: "1,5 KB", "2,3 MB" */
+export function formatFileSize(bytes: number): string {
+  if (!isFinite(bytes) || bytes < 0) return DASH
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  const value = bytes / Math.pow(1024, i)
+  return `${formatNumber(value, i === 0 ? 0 : 1)} ${units[i]}`
+}
+
+/** Relativ tid: "2 timer siden", "om 3 dager", "i morgen" */
+export function relativeTime(date: string | Date): string {
+  const d = toDate(date)
+  if (!d) return DASH
+  relativeFmt ??= new Intl.RelativeTimeFormat(LOCALE, { numeric: 'auto' })
+
+  const diffMs = d.getTime() - Date.now()
+  const absSec = Math.abs(diffMs / 1000)
+
+  const thresholds: [number, Intl.RelativeTimeFormatUnit, number][] = [
+    [60, 'second', 1],
+    [3600, 'minute', 60],
+    [86400, 'hour', 3600],
+    [2592000, 'day', 86400],
+    [31536000, 'month', 2592000],
+    [Infinity, 'year', 31536000]
+  ]
+
+  for (const [limit, unit, divisor] of thresholds) {
+    if (absSec < limit) {
+      return relativeFmt.format(Math.round(diffMs / 1000 / divisor), unit)
+    }
+  }
+
+  return DASH
+}


### PR DESCRIPTION
## Summary
- Adds 6 formatter functions using `nb-NO` locale via Intl APIs
- `formatCurrency`, `formatDate`, `formatDateTime`, `formatNumber`, `formatFileSize`, `relativeTime`
- Lazy-cached Intl instances for performance
- Graceful handling of invalid input (NaN, Infinity, invalid dates → en-dash)
- 26 unit tests covering all functions and edge cases

Part of #5. Remaining items (queryClient, eslint config, tsconfig.base.json) require package.json changes — awaiting infra-approval.

## Test plan
- [x] All 26 formatter tests pass
- [x] Full test suite passes (88 tests)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)