### PR TITLE
fix: QA findings for formatters (#5)

### DIFF
--- a/src/lib/__tests__/formatters.test.ts
+++ b/src/lib/__tests__/formatters.test.ts
@@ -50,6 +50,14 @@ describe('formatDate', () => {
   it('returnerer tankestrek for ugyldig dato', () => {
     expect(formatDate('ugyldig')).toBe('\u2013')
   })
+
+  it('returnerer tankestrek for null', () => {
+    expect(formatDate(null as unknown as string)).toBe('\u2013')
+  })
+
+  it('returnerer tankestrek for undefined', () => {
+    expect(formatDate(undefined as unknown as string)).toBe('\u2013')
+  })
 })
 
 describe('formatDateTime', () => {

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -14,6 +14,7 @@ let relativeFmt: Intl.RelativeTimeFormat
 
 /** Konverterer string | Date til Date, eller null ved ugyldig input */
 function toDate(input: string | Date): Date | null {
+  if (input == null) return null
   const d = input instanceof Date ? input : new Date(input)
   return isNaN(d.getTime()) ? null : d
 }
@@ -44,13 +45,20 @@ export function formatDateTime(date: string | Date): string {
   return dateTimeFmt.format(d)
 }
 
+// Cache for formatNumber med ulike desimalverdier
+const numberFmtCache = new Map<number | undefined, Intl.NumberFormat>()
+
 /** Formaterer tall med norsk tusenskilletegn og valgfritt antall desimaler */
 export function formatNumber(num: number, decimals?: number): string {
   if (!isFinite(num)) return DASH
-  const fmt = new Intl.NumberFormat(LOCALE, {
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals
-  })
+  let fmt = numberFmtCache.get(decimals)
+  if (!fmt) {
+    fmt = new Intl.NumberFormat(LOCALE, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals
+    })
+    numberFmtCache.set(decimals, fmt)
+  }
   return fmt.format(num)
 }
 


### PR DESCRIPTION
## Summary
- Fix `toDate()` to return null for null/undefined input (previously returned epoch 1970-01-01)
- Add `Map` cache for `formatNumber` Intl.NumberFormat instances
- Add tests for null/undefined edge cases

Follow-up to PR #10.

## Test plan
- [x] 90 tests pass (2 new tests added)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)