### PR TITLE
fix: add root eslint.config.js (QA follow-up for #13)

### DIFF
--- a/config/eslint.base.js
+++ b/config/eslint.base.js
@@ -37,10 +37,12 @@ export default tseslint.config(
     },
   },
   {
-    files: ['**/*.test.{ts,tsx}', '**/test/**/*.{ts,tsx}'],
+    files: ['**/*.test.{ts,tsx}', '**/test/**/*.{ts,tsx}', '**/__tests__/**/*.{ts,tsx}'],
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
       'react-refresh/only-export-components': 'off',
+      'react-hooks/globals': 'off',
     },
   },
 )

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+import baseConfig from './config/eslint.base.js'
+
+export default [...baseConfig]

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -125,6 +125,7 @@ export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
 
     // Sjekk sesjon ved mount
     useEffect(() => {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- setState i async callback er trygt
       fetchUser().finally(() => setIsLoading(false))
     }, [fetchUser])
 

--- a/src/config/__tests__/config-exports.test.ts
+++ b/src/config/__tests__/config-exports.test.ts
@@ -36,16 +36,22 @@ describe('Eksporterbar eslint-config', () => {
     expect(hasReactHooks).toBe(true)
   })
 
-  it('har no-unused-vars som warn med argsIgnorePattern (siste config vinner)', async () => {
+  it('har no-unused-vars som warn med argsIgnorePattern for produksjonskode', async () => {
     const mod = await import(eslintConfigPath)
     const config = mod.default as Array<Record<string, unknown>>
-    // Finn siste entry med no-unused-vars (den som vinner i flat config)
-    const withRules = config.filter(
-      (c) => c.rules && typeof c.rules === 'object' && '@typescript-eslint/no-unused-vars' in (c.rules as Record<string, unknown>)
+    // Finn siste non-test entry med no-unused-vars (den som vinner for produksjonskode)
+    const prodEntries = config.filter(
+      (c) =>
+        c.rules &&
+        typeof c.rules === 'object' &&
+        '@typescript-eslint/no-unused-vars' in (c.rules as Record<string, unknown>) &&
+        c.files &&
+        Array.isArray(c.files) &&
+        (c.files as string[]).some((f) => f.includes('*.{ts,tsx}') && !f.includes('test'))
     )
-    expect(withRules.length).toBeGreaterThan(0)
-    const lastEntry = withRules[withRules.length - 1]
-    const rule = (lastEntry.rules as Record<string, unknown>)['@typescript-eslint/no-unused-vars']
+    expect(prodEntries.length).toBeGreaterThan(0)
+    const prodEntry = prodEntries[prodEntries.length - 1]
+    const rule = (prodEntry.rules as Record<string, unknown>)['@typescript-eslint/no-unused-vars']
     expect(Array.isArray(rule)).toBe(true)
     expect((rule as unknown[])[0]).toBe('warn')
     expect((rule as unknown[])[1]).toHaveProperty('argsIgnorePattern', '^_')


### PR DESCRIPTION
## Summary
- Add root `eslint.config.js` so `npm run lint` actually works (QA finding from #13)
- Relax `react-hooks/globals` and `no-unused-vars` for test files in base config
- Suppress false positive `react-hooks/set-state-in-effect` in AuthContext (async callback is safe)

## Test plan
- [x] `npm run lint` passes
- [x] All 104 tests pass