### PR TITLE
feat: add createQueryClient factory (closes #12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "PRIVATE",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@tanstack/react-query": "^5.96.2",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.0.0",
         "@types/react": "^19.0.0",
@@ -1481,6 +1482,34 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.96.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.2.tgz",
+      "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.96.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.2.tgz",
+      "integrity": "sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.96.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,12 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "react-router-dom": "^6.0.0 || ^7.0.0"
+    "react-router-dom": "^6.0.0 || ^7.0.0",
+    "@tanstack/react-query": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@tanstack/react-query": "^5.96.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^19.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,9 @@ export type { ErrorBoundaryProps } from './components/ErrorBoundary'
 export { createProtectedRoute } from './components/ProtectedRoute'
 export type { ProtectedRouteProps } from './components/ProtectedRoute'
 
+// Query
+export { createQueryClient } from './query/queryClient'
+
 // Formatters
 export {
   formatCurrency,

--- a/src/query/__tests__/queryClient.test.ts
+++ b/src/query/__tests__/queryClient.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { createQueryClient } from '../queryClient'
+
+describe('createQueryClient', () => {
+  it('returnerer QueryClient med staleTime 300000 (5 min)', () => {
+    const client = createQueryClient()
+    const defaults = client.getDefaultOptions()
+    expect(defaults.queries?.staleTime).toBe(300_000)
+  })
+
+  it('returnerer QueryClient med retry: 1', () => {
+    const client = createQueryClient()
+    const defaults = client.getDefaultOptions()
+    expect(defaults.queries?.retry).toBe(1)
+  })
+
+  it('returnerer QueryClient med gcTime 300000 (5 min)', () => {
+    const client = createQueryClient()
+    const defaults = client.getDefaultOptions()
+    expect(defaults.queries?.gcTime).toBe(300_000)
+  })
+
+  it('overrides kan overskrive staleTime', () => {
+    const client = createQueryClient({ queries: { staleTime: 0 } })
+    const defaults = client.getDefaultOptions()
+    expect(defaults.queries?.staleTime).toBe(0)
+  })
+
+  it('overrides beholder andre defaults', () => {
+    const client = createQueryClient({ queries: { staleTime: 0 } })
+    const defaults = client.getDefaultOptions()
+    expect(defaults.queries?.retry).toBe(1)
+    expect(defaults.queries?.gcTime).toBe(300_000)
+  })
+
+  it('overrides kan overskrive retry', () => {
+    const client = createQueryClient({ queries: { retry: 3 } })
+    const defaults = client.getDefaultOptions()
+    expect(defaults.queries?.retry).toBe(3)
+  })
+
+  it('returnerer en ny instans ved hvert kall', () => {
+    const client1 = createQueryClient()
+    const client2 = createQueryClient()
+    expect(client1).not.toBe(client2)
+  })
+})

--- a/src/query/queryClient.ts
+++ b/src/query/queryClient.ts
@@ -1,0 +1,26 @@
+import { QueryClient } from '@tanstack/react-query'
+import type { DefaultOptions } from '@tanstack/react-query'
+
+/**
+ * Oppretter en QueryClient med fornuftige defaults for grunnmur-apper.
+ *
+ * Defaults:
+ * - `staleTime`: 300 000 ms (5 min) — reduserer unødvendige refetches
+ * - `retry`: 1 — én retry, unngår aggressive retry-loops
+ * - `gcTime`: 300 000 ms (5 min) — standard cache-levetid
+ *
+ * @param overrides - Valgfri konfigurasjon som merges med defaults
+ */
+export function createQueryClient(overrides?: DefaultOptions): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 300_000,
+        retry: 1,
+        gcTime: 300_000,
+        ...overrides?.queries,
+      },
+      mutations: overrides?.mutations,
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- Adds `createQueryClient()` factory that wraps `@tanstack/react-query` `QueryClient` with sensible defaults (staleTime: 5min, retry: 1, gcTime: 5min)
- Accepts `DefaultOptions` overrides for app-specific configuration
- Adds `@tanstack/react-query` as peerDependency and devDependency

## Test plan
- [x] Default staleTime (300000ms) verified
- [x] Default retry (1) verified
- [x] Default gcTime (300000ms) verified
- [x] Overrides merge correctly with defaults
- [x] Each call returns a new instance
- [x] All 111 tests pass, build succeeds

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)