### PR TITLE
fix: QA findings for createQueryClient (#12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
     "react-router-dom": "^6.0.0 || ^7.0.0",
     "@tanstack/react-query": "^5.0.0"
   },
+  "peerDependenciesMeta": {
+    "@tanstack/react-query": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tanstack/react-query": "^5.96.2",

--- a/src/query/__tests__/queryClient.test.ts
+++ b/src/query/__tests__/queryClient.test.ts
@@ -39,6 +39,20 @@ describe('createQueryClient', () => {
     expect(defaults.queries?.retry).toBe(3)
   })
 
+  it('overrides kan sette mutations-config', () => {
+    const client = createQueryClient({ mutations: { retry: 2 } })
+    const defaults = client.getDefaultOptions()
+    expect(defaults.mutations?.retry).toBe(2)
+  })
+
+  it('tomt overrides-objekt gir defaults', () => {
+    const client = createQueryClient({})
+    const defaults = client.getDefaultOptions()
+    expect(defaults.queries?.staleTime).toBe(300_000)
+    expect(defaults.queries?.retry).toBe(1)
+    expect(defaults.queries?.gcTime).toBe(300_000)
+  })
+
   it('returnerer en ny instans ved hvert kall', () => {
     const client1 = createQueryClient()
     const client2 = createQueryClient()


### PR DESCRIPTION
## Summary
- Added test for `mutations` override in createQueryClient
- Added test for empty overrides object `{}`
- Made `@tanstack/react-query` an optional peerDependency via `peerDependenciesMeta`

Follows up on #16, addresses QA review findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)