### PR TITLE
fix: exclude runtime React from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Forhindrer at konsumenter (biologportal/lo-finans/6810/styreportal) får
+# TO React-instanser i bundle. Grunnmur installerer react/react-dom i sine
+# devDependencies (for tester), men de skal IKKE shippes til consumers —
+# react er en peerDependency og må komme fra konsumentens egen node_modules.
+# Vi beholder @types/react etc. så TypeScript-kompilering fortsatt fungerer.
+node_modules/react
+node_modules/react-dom
+node_modules/.package-lock.json
+.git
+coverage
+*.log


### PR DESCRIPTION
## Summary

- Add `.dockerignore` that excludes `node_modules/react` and `node_modules/react-dom` from any Docker build context that copies this repo
- Prevents the two-React-copies bug where consumer apps end up bundling both their own React and grunnmur's devDep React, causing `Cannot read properties of null (reading 'useState')` and a white production page

## Background

On 2026-04-10 four consecutive deploys to `biologportal` failed smoke-test [7/7] with the white-page React error. Root cause: commit `2be37a4` in biologportal switched grunnmur-frontend consumption to Docker `additional_contexts`, which copies the entire grunnmur directory — including `node_modules/react` from devDeps — into the build container. Vite then bundled two separate React instances, and components from grunnmur (`AuthProvider`, `ErrorBoundary`, ...) called `useState` against their own React copy whose dispatcher is null.

`resolve.dedupe` in Vite alone does not fix this when the linked package has its own real `node_modules/react` next to its compiled output, because Node module resolution traverses up from grunnmur's `dist/*.js` and finds `/grunnmur-frontend/node_modules/react` before it reaches the consumer's `/app/node_modules/react`.

Fixing it centrally here means all four downstream apps (lo-finans, biologportal, 6810, styreportal) get the fix automatically the next time they rebuild their frontend, without each having to know about this.

## What's preserved

- `@types/react`, `@types/react-dom`, `react-router-dom`, `@tanstack/react-query` and the rest of `node_modules/` are still copied — `tsc -b` in consumer apps needs these to resolve the type imports inside grunnmur's `.d.ts` files.
- React is a `peerDependency` here, so removing the runtime React copy doesn't affect grunnmur's own contract with consumers.

## Test plan

- [x] Verified locally: biologportal frontend now builds and smoke-test [7/7] passes against both `http://localhost:9102` and `https://portal.leienbiolog.no`
- [x] Confirmed bundle has exactly one React instance (`__CLIENT_INTERNALS` × 3, `19.2.4` × 6)
- [ ] CI (test + test-full) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)