### PR TITLE
docs(claude): document .dockerignore decision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,40 @@ npm run lint      # ESLint
 - Semver-versjonering (major for breaking, minor for features, patch for bugfiks)
 - Tynn og stabil — konfigurasjon via callbacks, ikke feature-flags
 - Alle eksporterte funksjoner skal ha JSDoc-kommentarer
+
+## Viktig: `.dockerignore` ekskluderer runtime-React
+
+`.dockerignore` i rota ekskluderer:
+
+```
+node_modules/react
+node_modules/react-dom
+node_modules/.package-lock.json
+```
+
+**Hvorfor:** Konsumentapper (lo-finans, biologportal, 6810, styreportal) bruker
+oss via `file:../../grunnmur-frontend` og kopierer hele denne mappa inn i
+Docker build-konteksten via `additional_contexts` + `COPY --from=grunnmur-frontend`.
+Hvis vår `node_modules/react` følger med, ender konsumenten opp med to
+React-instanser i bundlet (en fra grunnmurs node_modules, en fra konsumentens
+egen) — og alle hooks fra grunnmur (AuthProvider, ErrorBoundary etc.) krasjer
+med `Cannot read properties of null (reading 'useState')` på initial render.
+
+Dette traff biologportal og lo-finans hardt 2026-04-10 — fire påfølgende
+deploys i biologportal feilet smoke-test [7/7] før rotårsaken ble identifisert.
+Se PR #24 og hvit side-incident i memory for full historikk.
+
+**Hva som fortsatt shippes:** `@types/react`, `@types/react-dom`,
+`@tanstack/react-query`, `react-router-dom` og resten av `node_modules/`.
+Konsumentene trenger dette for at `tsc -b` skal kunne resolve type-imports
+fra våre kompilerte `.d.ts`-filer (uten `@types/react` feiler kompilering med
+`'ErrorBoundary' cannot be used as a JSX component`).
+
+**Hva som er trygt å fjerne hvis du må kutte build-context-størrelse senere:**
+Kun `react` og `react-dom`. Ikke fjern `@types/react` eller `node_modules` som
+helhet. React er en `peerDependency` her, så konsumentene har alltid sin egen
+runtime React tilgjengelig.
+
+**Fjern aldri `.dockerignore` uten å varsle alle konsumenter** — fjerning
+gjeninnfører bug-en. Hver konsument har en defensiv `RUN rm -rf` i sine egne
+Dockerfiler som beskyttelse, men det er bedre å holde denne fila intakt.


### PR DESCRIPTION
## Summary

Documents the `.dockerignore` decision (PR #24) and its impact on consumer apps. Explains:
- Why `node_modules/react` and `node_modules/react-dom` are excluded
- What's still shipped (`@types/react`, etc.) and why
- What consumers need to know about the @types/react preservation requirement
- That removing this file regresses the white-page bug

Pure documentation. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)