### PR TITLE
Fix #31: add getSession to avoid 401 console logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Alle vesentlige endringer i dette prosjektet dokumenteres her.
 Formatet er basert pa [Keep a Changelog](https://keepachangelog.com/nb-NO/1.1.0/),
 og prosjektet folger [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Lagt til
+- `authApi.getSession<TUser>()` — sesjonssjekk mot `/auth/session` (konfigurerbar via `sessionEndpoint`) som returnerer `{ authenticated, user? }`. Lar backend svare 2xx for anonyme brukere slik at nettleseren ikke logger 401 i konsollen (Lighthouse `errors-in-console`).
+- `AuthProviderConfig.useSessionEndpoint` — flagg som faar `AuthProvider` til aa bruke `getSession` i stedet for `getMe` ved initial sesjonssjekk. `getMe` beholdes uendret for bakoverkompatibilitet.
+
 ## [1.0.0] - 2026-04-08
 
 Forste stabile release av `@tommyskogstad/frontend-core`.

--- a/README.md
+++ b/README.md
@@ -157,12 +157,30 @@ const { AuthProvider, useAuth, ProtectedRoute } = createAuthProvider<MyUser>({
   loginPath: '/logg-inn',                 // Sti til innloggingsside (default: '/login')
   onLogout: () => queryClient.clear(),    // Callback ved utlogging
   parseUser: (data) => data as MyUser,    // Custom parsing av /me-respons
+  // Unngå 401-logging i konsollen (krever at backend returnerer 2xx på /auth/session):
+  useSessionEndpoint: true,               // Bruk session-endepunkt i stedet for /me
   // Valgfrie endepunkt-overrides:
   requestCodeEndpoint: '/auth/request-code',  // default
   verifyCodeEndpoint: '/auth/verify-code',    // default
   meEndpoint: '/auth/me',                     // default
   logoutEndpoint: '/auth/logout',             // default
+  sessionEndpoint: '/auth/session',           // default
 })
+```
+
+**Session-endepunkt** — når `useSessionEndpoint: true`, kaller `AuthProvider`
+`sessionEndpoint` i stedet for `meEndpoint` ved initial sesjonssjekk.
+Backend må da returnere 2xx med `{ authenticated: boolean, user?: TUser }`
+slik at nettleseren ikke logger 401-nettverksfeil i konsollen for anonyme
+brukere (Lighthouse `errors-in-console`). `getMe` beholdes uendret for
+bakoverkompatibilitet.
+
+```ts
+// Autentisert respons
+{ "authenticated": true, "user": { "id": 1, "email": "ola@example.com" } }
+
+// Anonym respons (fortsatt HTTP 200)
+{ "authenticated": false }
 ```
 
 **`AuthProvider`** — wrapper-komponent som handterer sesjon:

--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -242,6 +242,166 @@ describe('createAuthProvider', () => {
     spy.mockRestore()
   })
 
+  it('useSessionEndpoint=true: anonym session setter user=null uten å kalle getMe', async () => {
+    const calls: string[] = []
+    vi.mocked(mockClient.request).mockImplementation(async (path: string) => {
+      calls.push(path)
+      if (path === '/auth/session') return { authenticated: false }
+      throw new Error(`Uventet kall til ${path}`)
+    })
+
+    const { AuthProvider, useAuth } = createAuthProvider<TestUser>({
+      apiClient: mockClient,
+      useSessionEndpoint: true,
+    })
+
+    function TestComponent() {
+      const { isAuthenticated, isLoading, user } = useAuth()
+      return (
+        <div>
+          <span data-testid="loading">{String(isLoading)}</span>
+          <span data-testid="auth">{String(isAuthenticated)}</span>
+          <span data-testid="user">{user ? user.email : 'null'}</span>
+        </div>
+      )
+    }
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    expect(screen.getByTestId('auth').textContent).toBe('false')
+    expect(screen.getByTestId('user').textContent).toBe('null')
+    expect(calls).toEqual(['/auth/session'])
+    expect(calls).not.toContain('/auth/me')
+  })
+
+  it('useSessionEndpoint=true: autentisert session setter user direkte', async () => {
+    vi.mocked(mockClient.request).mockImplementation(async (path: string) => {
+      if (path === '/auth/session') {
+        return { authenticated: true, user: testUser }
+      }
+      throw new Error(`Uventet kall til ${path}`)
+    })
+
+    const { AuthProvider, useAuth } = createAuthProvider<TestUser>({
+      apiClient: mockClient,
+      useSessionEndpoint: true,
+    })
+
+    function TestComponent() {
+      const { isAuthenticated, isLoading, user } = useAuth()
+      return (
+        <div>
+          <span data-testid="loading">{String(isLoading)}</span>
+          <span data-testid="auth">{String(isAuthenticated)}</span>
+          <span data-testid="user">{user ? user.email : 'null'}</span>
+        </div>
+      )
+    }
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth').textContent).toBe('true')
+    })
+
+    expect(screen.getByTestId('user').textContent).toBe('ola@example.com')
+  })
+
+  it('useSessionEndpoint=true: parseUser brukes på user fra session-respons', async () => {
+    interface CustomUser {
+      userId: number
+      displayName: string
+    }
+
+    vi.mocked(mockClient.request).mockImplementation(async (path: string) => {
+      if (path === '/auth/session') {
+        return {
+          authenticated: true,
+          user: { user_id: 42, display_name: 'Kari' },
+        }
+      }
+      throw new Error(`Uventet kall til ${path}`)
+    })
+
+    const { AuthProvider, useAuth } = createAuthProvider<CustomUser>({
+      apiClient: mockClient,
+      useSessionEndpoint: true,
+      parseUser: (data) => {
+        const raw = data as { user_id: number; display_name: string }
+        return { userId: raw.user_id, displayName: raw.display_name }
+      },
+    })
+
+    function TestComponent() {
+      const { user, isLoading } = useAuth()
+      return (
+        <div>
+          <span data-testid="loading">{String(isLoading)}</span>
+          <span data-testid="name">{user ? user.displayName : 'null'}</span>
+        </div>
+      )
+    }
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    expect(screen.getByTestId('name').textContent).toBe('Kari')
+  })
+
+  it('uten useSessionEndpoint: getMe kalles som før (bakoverkompatibilitet)', async () => {
+    const calls: string[] = []
+    vi.mocked(mockClient.request).mockImplementation(async (path: string) => {
+      calls.push(path)
+      if (path === '/auth/me') return testUser
+      throw new Error(`Uventet kall til ${path}`)
+    })
+
+    const { AuthProvider, useAuth } = createAuthProvider<TestUser>({
+      apiClient: mockClient,
+    })
+
+    function TestComponent() {
+      const { isAuthenticated, isLoading } = useAuth()
+      return (
+        <div>
+          <span data-testid="loading">{String(isLoading)}</span>
+          <span data-testid="auth">{String(isAuthenticated)}</span>
+        </div>
+      )
+    }
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth').textContent).toBe('true')
+    })
+
+    expect(calls).toEqual(['/auth/me'])
+  })
+
   it('refreshUser henter brukerdata på nytt', async () => {
     let refreshCount = 0
     vi.mocked(mockClient.request).mockImplementation(async (path: string) => {

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -58,8 +58,16 @@ export interface AuthProviderConfig<TUser> extends AuthApiConfig {
   loginPath?: string
   /** Callback ved utlogging — f.eks. queryClient.clear() */
   onLogout?: () => void
-  /** Custom parsing av brukerdata fra /me-endepunktet */
+  /** Custom parsing av brukerdata fra /me- eller /session-endepunktet */
   parseUser?: (data: unknown) => TUser
+  /**
+   * Bruk session-endepunkt (2xx for både anonyme og autentiserte) i stedet for
+   * /me (som returnerer 401 for anonyme og logger nettverksfeil i konsollen).
+   *
+   * Krever at backend returnerer `{ authenticated: boolean, user?: TUser }` på
+   * `sessionEndpoint` (default: `/auth/session`). Default: false.
+   */
+  useSessionEndpoint?: boolean
 }
 
 /**
@@ -77,6 +85,7 @@ export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
     apiClient,
     onLogout: onLogoutCallback,
     parseUser,
+    useSessionEndpoint,
     ...authApiConfig
   } = config
 
@@ -91,6 +100,16 @@ export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
 
     const fetchUser = useCallback(async () => {
       try {
+        if (useSessionEndpoint) {
+          const session = await authApi.getSession<TUser>()
+          if (!session.authenticated || session.user === undefined) {
+            setUser(null)
+            return
+          }
+          const parsed = parseUser ? parseUser(session.user) : (session.user as TUser)
+          setUser(parsed)
+          return
+        }
         const data = await authApi.getMe<TUser>()
         const parsed = parseUser ? parseUser(data) : data
         setUser(parsed)

--- a/src/auth/authApi.test.ts
+++ b/src/auth/authApi.test.ts
@@ -77,6 +77,7 @@ describe('createAuthApi', () => {
       verifyCodeEndpoint: '/custom/verify',
       meEndpoint: '/custom/me',
       logoutEndpoint: '/custom/logout',
+      sessionEndpoint: '/custom/session',
     })
 
     await authApi.requestCode('ola@example.com')
@@ -87,5 +88,33 @@ describe('createAuthApi', () => {
 
     await authApi.logout()
     expect(mockClient.request).toHaveBeenCalledWith('/custom/logout', expect.any(Object))
+
+    vi.mocked(mockClient.request).mockResolvedValue({ authenticated: false })
+    await authApi.getSession()
+    expect(mockClient.request).toHaveBeenCalledWith('/custom/session')
+  })
+
+  it('getSession returnerer anonym respons fra default-endepunkt', async () => {
+    vi.mocked(mockClient.request).mockResolvedValue({ authenticated: false })
+
+    const authApi = createAuthApi(mockClient)
+    const result = await authApi.getSession()
+
+    expect(mockClient.request).toHaveBeenCalledWith('/auth/session')
+    expect(result).toEqual({ authenticated: false })
+  })
+
+  it('getSession returnerer autentisert respons med user', async () => {
+    const mockUser = { id: 1, email: 'ola@example.com' }
+    vi.mocked(mockClient.request).mockResolvedValue({
+      authenticated: true,
+      user: mockUser,
+    })
+
+    const authApi = createAuthApi(mockClient)
+    const result = await authApi.getSession<typeof mockUser>()
+
+    expect(mockClient.request).toHaveBeenCalledWith('/auth/session')
+    expect(result).toEqual({ authenticated: true, user: mockUser })
   })
 })

--- a/src/auth/authApi.ts
+++ b/src/auth/authApi.ts
@@ -21,6 +21,17 @@ export interface LoginResponse {
   csrfToken?: string
 }
 
+/**
+ * Respons fra getSession — returnerer 2xx for både autentiserte og anonyme
+ * brukere, slik at nettleseren ikke logger 401 i konsollen ved sessjonssjekk.
+ */
+export interface SessionResponse<TUser = unknown> {
+  /** Om bruker er autentisert */
+  authenticated: boolean
+  /** Brukerdata (kun satt når authenticated=true) */
+  user?: TUser
+}
+
 /** Auth-API returnert av createAuthApi() */
 export interface AuthApi {
   /** Send engangskode til e-post */
@@ -29,6 +40,8 @@ export interface AuthApi {
   verifyCode: (email: string, code: string) => Promise<LoginResponse>
   /** Hent innlogget bruker */
   getMe: <TUser>() => Promise<TUser>
+  /** Hent sesjonsstatus (2xx både for anonyme og autentiserte) */
+  getSession: <TUser>() => Promise<SessionResponse<TUser>>
   /** Logg ut */
   logout: () => Promise<void>
 }
@@ -43,6 +56,8 @@ export interface AuthApiConfig {
   meEndpoint?: string
   /** Endepunkt for utlogging (default: '/auth/logout') */
   logoutEndpoint?: string
+  /** Endepunkt for sesjonssjekk (default: '/auth/session') */
+  sessionEndpoint?: string
 }
 
 /**
@@ -57,6 +72,7 @@ export function createAuthApi(apiClient: ApiClient, config?: AuthApiConfig): Aut
   const verifyCodeEndpoint = config?.verifyCodeEndpoint ?? '/auth/verify-code'
   const meEndpoint = config?.meEndpoint ?? '/auth/me'
   const logoutEndpoint = config?.logoutEndpoint ?? '/auth/logout'
+  const sessionEndpoint = config?.sessionEndpoint ?? '/auth/session'
 
   async function requestCode(email: string): Promise<void> {
     await apiClient.request<void>(requestCodeEndpoint, {
@@ -76,11 +92,15 @@ export function createAuthApi(apiClient: ApiClient, config?: AuthApiConfig): Aut
     return apiClient.request<TUser>(meEndpoint)
   }
 
+  async function getSession<TUser>(): Promise<SessionResponse<TUser>> {
+    return apiClient.request<SessionResponse<TUser>>(sessionEndpoint)
+  }
+
   async function logout(): Promise<void> {
     await apiClient.request<void>(logoutEndpoint, {
       method: 'POST',
     })
   }
 
-  return { requestCode, verifyCode, getMe, logout }
+  return { requestCode, verifyCode, getMe, getSession, logout }
 }


### PR DESCRIPTION
## Summary
- Legger til `authApi.getSession<TUser>()` som treffer konfigurerbart `/auth/session`-endepunkt og returnerer `{ authenticated, user? }`.
- Ny `AuthProviderConfig.useSessionEndpoint`-flagg faar `AuthProvider` til aa bruke `getSession` i stedet for `getMe` ved initial sesjonssjekk, slik at nettleseren ikke logger 401 i konsollen for anonyme brukere (Lighthouse `errors-in-console`).
- `getMe` beholdes uendret for bakoverkompatibilitet.

Fixes #31

## Test plan
- [x] `npm test` — 119 tester gronne (10 nye i auth-modulen)
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Tas i bruk i 6810 via TommySkogstad/6810#125