### PR TITLE
QA follow-up #31: test 5xx path for getSession

### DIFF
--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -319,6 +319,41 @@ describe('createAuthProvider', () => {
     expect(screen.getByTestId('user').textContent).toBe('ola@example.com')
   })
 
+  it('useSessionEndpoint=true: session-feil (500) setter user=null og avslutter loading', async () => {
+    vi.mocked(mockClient.request).mockRejectedValue(
+      new ApiError('Server error', 500, 'Internal Server Error')
+    )
+
+    const { AuthProvider, useAuth } = createAuthProvider<TestUser>({
+      apiClient: mockClient,
+      useSessionEndpoint: true,
+    })
+
+    function TestComponent() {
+      const { isAuthenticated, isLoading, user } = useAuth()
+      return (
+        <div>
+          <span data-testid="loading">{String(isLoading)}</span>
+          <span data-testid="auth">{String(isAuthenticated)}</span>
+          <span data-testid="user">{user ? user.email : 'null'}</span>
+        </div>
+      )
+    }
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    expect(screen.getByTestId('auth').textContent).toBe('false')
+    expect(screen.getByTestId('user').textContent).toBe('null')
+  })
+
   it('useSessionEndpoint=true: parseUser brukes på user fra session-respons', async () => {
     interface CustomUser {
       userId: number

--- a/src/auth/authApi.ts
+++ b/src/auth/authApi.ts
@@ -65,7 +65,7 @@ export interface AuthApiConfig {
  *
  * @param apiClient - API-klient fra createApiClient()
  * @param config - Valgfri konfigurasjon av endepunkter
- * @returns AuthApi med requestCode, verifyCode, getMe, logout
+ * @returns AuthApi med requestCode, verifyCode, getMe, getSession, logout
  */
 export function createAuthApi(apiClient: ApiClient, config?: AuthApiConfig): AuthApi {
   const requestCodeEndpoint = config?.requestCodeEndpoint ?? '/auth/request-code'


### PR DESCRIPTION
## Summary
- Legger til test for 5xx-feil paa \`/auth/session\` naar \`useSessionEndpoint=true\` (verifiserer \`user=null\` og at \`isLoading\` avslutter).
- Oppdaterer JSDoc paa \`createAuthApi\` slik at \`@returns\` lister \`getSession\`.

Oppfolger av QA-funn paa #31 / PR #32.

## Test plan
- [x] \`npm test\` — 120 tester gronne (ny: session-5xx-test)
- [x] \`npm run lint\`
- [x] \`npm run build\`