### PR TITLE
Fix #46: konverter nettverksfeil til ApiError

### DIFF
--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -367,12 +367,28 @@ describe('request', () => {
     }
   })
 
-  it('propagerer nettverksfeil som TypeError', async () => {
+  it('konverterer nettverksfeil (fetch reject) til ApiError med status 0 og NetworkError', async () => {
+    mockFetch.mockRejectedValue(new TypeError('Failed to fetch'))
+
+    const client = createApiClient()
+
+    try {
+      await client.request('/test')
+      expect.fail('Skulle ha kastet ApiError')
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError)
+      const err = e as ApiError
+      expect(err.status).toBe(0)
+      expect(err.statusText).toBe('NetworkError')
+    }
+  })
+
+  it('konverterer nettverksfeil i formDataRequest til ApiError', async () => {
     mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'))
 
     const client = createApiClient()
 
-    await expect(client.request('/test')).rejects.toThrow(TypeError)
+    await expect(client.formDataRequest('/upload', new FormData())).rejects.toBeInstanceOf(ApiError)
   })
 })
 

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -192,12 +192,21 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
       body = JSON.stringify(options.body)
     }
 
-    const response = await fetch(`${basePath}${path}`, {
-      method,
-      headers,
-      body,
-      credentials: 'include',
-    })
+    let response: Response
+    try {
+      response = await fetch(`${basePath}${path}`, {
+        method,
+        headers,
+        body,
+        credentials: 'include',
+      })
+    } catch (err) {
+      throw new ApiError(
+        err instanceof TypeError ? 'Nettverksfeil — sjekk tilkoblingen' : String(err),
+        0,
+        'NetworkError'
+      )
+    }
 
     if (!response.ok) {
       return handleErrorResponse(response)
@@ -221,12 +230,21 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
     }
 
     // Ikke sett Content-Type — nettleseren setter multipart boundary selv
-    const response = await fetch(`${basePath}${path}`, {
-      method: upperMethod,
-      headers,
-      body: formData,
-      credentials: 'include',
-    })
+    let response: Response
+    try {
+      response = await fetch(`${basePath}${path}`, {
+        method: upperMethod,
+        headers,
+        body: formData,
+        credentials: 'include',
+      })
+    } catch (err) {
+      throw new ApiError(
+        err instanceof TypeError ? 'Nettverksfeil — sjekk tilkoblingen' : String(err),
+        0,
+        'NetworkError'
+      )
+    }
 
     if (!response.ok) {
       return handleErrorResponse(response)


### PR DESCRIPTION
Fixes #46

Wrapper `fetch()`-kallene i `request()` og `formDataRequest()` med try/catch. `TypeError` (nettverksfeil) konverteres til `ApiError` med `status: 0` og `statusText: 'NetworkError'` slik at `instanceof ApiError`-sjekker alltid fungerer korrekt.