### PR TITLE
chore(deps): bump typescript to 6.x (closes #52)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.14.2",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.58.2",
         "vitest": "^4.1.5"
       },
@@ -3439,9 +3439,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.14.2",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",
     "vitest": "^4.1.5"
   },


### PR DESCRIPTION
## Oppsummering

Bumper TypeScript fra `^5.7.0` til `^6.0.3` (sub-issue #52 av paraply #44).

| Fra | Til |
|-----|-----|
| typescript `^5.7.0` (installert 5.7.x) | typescript `^6.0.3` (installert 6.0.3) |

Kun `typescript` og tilhørende `package-lock.json`-oppdatering — ingen andre deps rørt.

## Verifikasjon

- `npm install` — 0 vulnerabilities, 230 pakker revidert.
- `npm run build` (tsc) — OK, `dist/` generert uten feil.
- `npm test` (vitest 4) — 246/246 tester passerer i 16 test-filer.
- `npm run lint` (eslint 10) — ren, ingen advarsler.
- Spot-check av `dist/*.d.ts` — alle forventede typer eksporteres fortsatt (`AuthContextValue`, `AuthProviderConfig`, `createAuthProvider`, `ApiClientConfig`, `ErrorBoundaryProps`, `ProtectedRouteProps`, `createQueryClient`, formatters, osv.).

## Interne tilpasninger

Ingen. TS 6.0.3 kompilerer eksisterende kode uendret. Ingen nye strictness-feil eller overload-endringer traff biblioteket.

## KRITISK: Forventet app-påvirkning

Fire konsumentapper lenker til dette biblioteket via `file:../../grunnmur-frontend` i `package.json`:

- biologportal
- lo-finans
- 6810
- styreportal

Når de neste gang kjører `npm install` vil de konsumere `dist/*.d.ts` generert av TS 6. I praksis skal dette gå smertefritt fordi output-formatet er kompatibelt, men IDE-er som fortsatt bruker TS 5.x internt kan vise type-warnings på strengere inferens fra TS 6. Hver app bør derfor også bumpes til TypeScript 6.x i sin egen devDependencies for å unngå drift mellom `.d.ts`-generator og consumer-compiler.

**Paraply #44 dekker oppfølgingen** — ingen nye issues opprettet i konsumentappene i denne PR-en.

## Sub-issue

Closes #52 (parent #44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)