### PR TITLE
ci: migrate test workflow to self-hosted NUC runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,13 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, nuc]
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: npm
 
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
## Summary
- Bytte `runs-on: ubuntu-latest` → `runs-on: [self-hosted, linux, nuc]` på `test.yml`
- Fjern `cache: npm` fra `setup-node@v6` (overflødig på self-hosted, `~/.npm` persisterer mellom runs)
- 2 nye runners registrert på NUC 2026-04-27 (`nuc-runner-grunnmur-frontend` + `-2`)

## Test plan
- [ ] CI grønn på denne PR-en
- [ ] Ingen consumere påvirkes — grunnmur-frontend bygges via `file:`-referanse i konsumenter, ikke via egen npm-publisert pakke

🤖 Generated with [Claude Code](https://claude.com/claude-code)