### PR TITLE
fix: also exclude @tanstack from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,20 @@
 # Forhindrer at konsumenter (biologportal/lo-finans/6810/styreportal) får
-# TO React-instanser i bundle. Grunnmur installerer react/react-dom i sine
-# devDependencies (for tester), men de skal IKKE shippes til consumers —
-# react er en peerDependency og må komme fra konsumentens egen node_modules.
+# TO instanser av runtime-deps i bundle. Grunnmur installerer react,
+# @tanstack/react-query osv. i sine devDependencies (for tester), men de
+# skal IKKE shippes til consumers — alle disse er peerDependencies og må
+# komme fra konsumentens egen node_modules.
+#
+# Symptomer ved dual-instance:
+#   * react/react-dom: hvit side (incident 2026-04-10), `useState` mot null
+#   * react-router-dom: <Outlet> rendrer ingenting, <Navigate> kaster
+#   * @tanstack/react-query: TS2322 "QueryClient ≠ QueryClient" (2026-04-27)
+#
 # Vi beholder @types/react etc. så TypeScript-kompilering fortsatt fungerer.
 node_modules/react
 node_modules/react-dom
 node_modules/react-router
 node_modules/react-router-dom
+node_modules/@tanstack
 node_modules/.package-lock.json
 .git
 coverage


### PR DESCRIPTION
## Summary
Legg `node_modules/@tanstack` til `.dockerignore` (i tillegg til de eksisterende react/react-router-eksluderingene) for å forhindre at dual-instance-bug-en treffer Docker-builds når @tanstack/react-query versjonene drifter mellom grunnmur og konsumenter.

## Bakgrunn
2026-04-27 manifestert dette i biologportal: TypeScript så to ulike `QueryClient`-typer fordi grunnmur-frontends `node_modules/@tanstack/query-core` ble kopiert inn i konsumenten via `file:`-link, parallelt med konsumentens egen kopi. CI fix er separat (rm i workflow), denne lukker også Docker-veien.

## Test plan
- [ ] CI grønn

🤖 Generated with [Claude Code](https://claude.com/claude-code)