### PR TITLE
Revert: also exclude @tanstack from .dockerignore (#64)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,20 +1,12 @@
 # Forhindrer at konsumenter (biologportal/lo-finans/6810/styreportal) får
-# TO instanser av runtime-deps i bundle. Grunnmur installerer react,
-# @tanstack/react-query osv. i sine devDependencies (for tester), men de
-# skal IKKE shippes til consumers — alle disse er peerDependencies og må
-# komme fra konsumentens egen node_modules.
-#
-# Symptomer ved dual-instance:
-#   * react/react-dom: hvit side (incident 2026-04-10), `useState` mot null
-#   * react-router-dom: <Outlet> rendrer ingenting, <Navigate> kaster
-#   * @tanstack/react-query: TS2322 "QueryClient ≠ QueryClient" (2026-04-27)
-#
+# TO React-instanser i bundle. Grunnmur installerer react/react-dom i sine
+# devDependencies (for tester), men de skal IKKE shippes til consumers —
+# react er en peerDependency og må komme fra konsumentens egen node_modules.
 # Vi beholder @types/react etc. så TypeScript-kompilering fortsatt fungerer.
 node_modules/react
 node_modules/react-dom
 node_modules/react-router
 node_modules/react-router-dom
-node_modules/@tanstack
 node_modules/.package-lock.json
 .git
 coverage


### PR DESCRIPTION
## Summary
Reverterer #64. `.dockerignore` exclusion av `@tanstack` overskuter — module-resolusjon i grunnmurs compiled `dist/queryClient.js` walker oppover i directory-treet (ikke sideveis til consumer's frontend/node_modules), så uten grunnmurs lokale kopi feiler bygget for ALLE consumers — også de som har egen `@tanstack/react-query`.

Bekreftet 2026-04-27 ved at 6810/styreportal CI feilet med "Could not resolve @tanstack/react-query imported by @tommyskogstad/frontend-core" etter å ha rm-et samme path i CI-workflowen. Samme effekt forventet i Docker-builds.

## Bakgrunn
TS2322-bugen i biologportal (dual QueryClient-typer) er reell, men løsningen er ikke å fjerne grunnmurs node_modules. Riktig fix er enten:
1. Sentralisere @tanstack/react-query-versjon mellom grunnmur og konsumenter (dependabot-grupper)
2. Vite/tsc paths-mapping i biologportal
3. Refaktorering av grunnmur-frontend slik at QueryClient-typer ikke krysser pakke-grenser

Disse vurderes i separat tech-debt-issue.

## Test plan
- [ ] CI grønn

🤖 Generated with [Claude Code](https://claude.com/claude-code)