### PR TITLE
fix: exclude node_modules/@tanstack from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,13 @@
 # Forhindrer at konsumenter (biologportal/lo-finans/6810/styreportal) får
-# TO React-instanser i bundle. Grunnmur installerer react/react-dom i sine
-# devDependencies (for tester), men de skal IKKE shippes til consumers —
-# react er en peerDependency og må komme fra konsumentens egen node_modules.
-# Vi beholder @types/react etc. så TypeScript-kompilering fortsatt fungerer.
+# TO instanser av peerDependency-pakker i bundle. Grunnmur installerer disse
+# i devDependencies (for tester), men de skal IKKE shippes til consumers —
+# de er peerDependencies og må komme fra konsumentens egen node_modules.
+# Vi beholder @types/* etc. så TypeScript-kompilering fortsatt fungerer.
 node_modules/react
 node_modules/react-dom
 node_modules/react-router
 node_modules/react-router-dom
+node_modules/@tanstack
 node_modules/.package-lock.json
 .git
 coverage


### PR DESCRIPTION
## Problem
`grunnmur-frontend` installerer `@tanstack/react-query` som devDependency (for egne tester). Når konsumenter (biologportal, lo-finans etc.) kopierer grunnmur-mappen inn i Docker build-konteksten, følger grunnmurs egne `node_modules/@tanstack` med. Dette gir **to separate `QueryClient`-typer** — én fra konsumentens `node_modules`, én fra grunnmurs — og forårsaker TS2322.

Sub-issue av biologportal#502 / biologportal#483.

## Løsning
Legger `node_modules/@tanstack` til i `.dockerignore`, identisk med det etablerte mønsteret for `react`, `react-dom`, `react-router` og `react-router-dom`.

**Hvorfor ikke fjerne fra devDependencies?**
`@tanstack/react-query` er merket `optional` i `peerDependenciesMeta`, så npm 7+ vil ikke auto-installere den som peer dep. Grunnmurs egne tester (`queryClient.test.ts`) bruker pakken direkte og ville da feile. DevDependency for lokalt testarbeid er korrekt — den skal bare ikke shippes til konsumenter via Docker.

## Verifisering
- Alle 246 tester består etter endringen
- `.dockerignore` vil ekskludere `node_modules/@tanstack` fra build-konteksten

Fixes biologportal#502