### PR TITLE
Fix #68: AuthContext useEffect cleanup (isMountedRef)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tommyskogstad/frontend-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Felles frontend-bibliotek for Kotlin/Ktor-apper",
   "type": "module",
   "main": "dist/index.js",

--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -580,4 +580,53 @@ describe('createAuthProvider', () => {
 
     expect(screen.getByTestId('user').textContent).toBe('user-2@example.com')
   })
+
+  it('unmount under pågående fetchUser produserer ikke feil etter resolve', async () => {
+    let resolveMe: ((value: TestUser) => void) | undefined
+
+    vi.mocked(mockClient.request).mockImplementation(async (path: string) => {
+      if (path === '/auth/me') {
+        return new Promise<TestUser>((resolve) => {
+          resolveMe = resolve
+        })
+      }
+      return undefined
+    })
+
+    const { AuthProvider, useAuth } = createAuthProvider<TestUser>({
+      apiClient: mockClient,
+    })
+
+    function TestComponent() {
+      const { isLoading } = useAuth()
+      return <span data-testid="loading">{String(isLoading)}</span>
+    }
+
+    const { unmount } = render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    expect(screen.getByTestId('loading').textContent).toBe('true')
+    expect(resolveMe).toBeDefined()
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Unmount FØR promisen resolver
+    unmount()
+
+    // Resolver promisen etter unmount — uten cancel-flag ville dette kalt
+    // setIsLoading(false) og setUser(parsed) på unmountet komponent,
+    // noe som i jsdom-teardown-kontekst trigger 'window is not defined'
+    await act(async () => {
+      resolveMe!(testUser)
+      await Promise.resolve()
+    })
+
+    const errors = errorSpy.mock.calls
+    expect(errors).toHaveLength(0)
+
+    errorSpy.mockRestore()
+  })
 })

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -25,7 +25,7 @@
  * ```
  */
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import type { ApiClient } from '../api/apiClient'
 import { ApiError } from '../api/apiClient'
@@ -97,11 +97,13 @@ export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
   function AuthProvider({ children }: { children: ReactNode }) {
     const [user, setUser] = useState<TUser | null>(null)
     const [isLoading, setIsLoading] = useState(true)
+    const isMountedRef = useRef(true)
 
     const fetchUser = useCallback(async () => {
       try {
         if (useSessionEndpoint) {
           const session = await authApi.getSession<TUser>()
+          if (!isMountedRef.current) return
           if (!session.authenticated || session.user === undefined) {
             setUser(null)
             return
@@ -111,9 +113,11 @@ export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
           return
         }
         const data = await authApi.getMe<TUser>()
+        if (!isMountedRef.current) return
         const parsed = parseUser ? parseUser(data) : data
         setUser(parsed)
       } catch (error) {
+        if (!isMountedRef.current) return
         // 401 betyr at brukeren ikke er innlogget — det er forventet
         if (error instanceof ApiError && error.is(401)) {
           setUser(null)
@@ -142,9 +146,13 @@ export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
       onLogoutCallback?.()
     }, [])
 
-    // Sjekk sesjon ved mount
+    // Sjekk sesjon ved mount — cleanup hindrer state-oppdatering etter unmount
     useEffect(() => {
-      fetchUser().finally(() => setIsLoading(false))
+      isMountedRef.current = true
+      fetchUser().finally(() => {
+        if (isMountedRef.current) setIsLoading(false)
+      })
+      return () => { isMountedRef.current = false }
     }, [fetchUser])
 
     const value = useMemo<AuthContextValue<TUser>>(() => ({


### PR DESCRIPTION
Fixes #68

## Endringer

- `src/auth/AuthContext.tsx`: La til `isMountedRef = useRef(true)` i `AuthProvider`. Cleanup i `useEffect` setter `isMountedRef.current = false` ved unmount. Guard-sjekk etter alle `await`-punkter i `fetchUser` og i `.finally(() => setIsLoading(false))`.
- `src/auth/AuthContext.test.tsx`: Ny test som verifiserer at unmount under pågående `fetchUser`-promise ikke produserer konsollfeil.
- `package.json`: Version bump 1.0.0 → 1.0.1 (patch).