### PR TITLE
Fix #70: add authApi and onLogoutCallback to logout useCallback deps

### DIFF
--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -581,6 +581,42 @@ describe('createAuthProvider', () => {
     expect(screen.getByTestId('user').textContent).toBe('user-2@example.com')
   })
 
+  it('logout uten onLogout-callback kaster ikke feil og setter isAuthenticated=false', async () => {
+    vi.mocked(mockClient.request).mockImplementation(async (path: string) => {
+      if (path === '/auth/me') return testUser
+      return undefined
+    })
+
+    const { AuthProvider, useAuth } = createAuthProvider<TestUser>({
+      apiClient: mockClient,
+      // onLogout ikke oppgitt — verifiserer at logout?.() håndteres korrekt
+    })
+
+    let logoutFn: (() => Promise<void>) | null = null
+
+    function TestComponent() {
+      const { isAuthenticated, logout } = useAuth()
+      logoutFn = logout
+      return <span data-testid="auth">{String(isAuthenticated)}</span>
+    }
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth').textContent).toBe('true')
+    })
+
+    await act(async () => {
+      await logoutFn!()
+    })
+
+    expect(screen.getByTestId('auth').textContent).toBe('false')
+  })
+
   it('unmount under pågående fetchUser produserer ikke feil etter resolve', async () => {
     let resolveMe: ((value: TestUser) => void) | undefined
 

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -144,7 +144,7 @@ export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
       await authApi.logout()
       setUser(null)
       onLogoutCallback?.()
-    }, [])
+    }, [authApi, onLogoutCallback])
 
     // Sjekk sesjon ved mount — cleanup hindrer state-oppdatering etter unmount
     useEffect(() => {


### PR DESCRIPTION
Fixes #70

Legger til `authApi` og `onLogoutCallback` i deps-arrayen til `logout`-callback i `AuthContext.tsx`. Begge er stabile factory-scope referanser, så endringen medfører ingen ekstra re-rendering — men retter brudd på React-hookregelen om uttømmende deps.

Ny test dekker `logout` uten `onLogout`-callback (den udokumenterte `?.()-stien).