### PR TITLE
Fix #71: derive VERSION from package.json

### DIFF
--- a/src/config/__tests__/config-exports.test.ts
+++ b/src/config/__tests__/config-exports.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync, existsSync } from 'fs'
 import { resolve } from 'path'
+import { VERSION } from '../../index'
 
 const ROOT = resolve(__dirname, '..', '..', '..')
 
@@ -91,6 +92,13 @@ describe('Eksporterbar tsconfig.base.json', () => {
     expect(config.compilerOptions.rootDir).toBeUndefined()
     expect(config.compilerOptions.declaration).toBeUndefined()
     expect(config.compilerOptions.declarationDir).toBeUndefined()
+  })
+})
+
+describe('VERSION er synkronisert med package.json', () => {
+  it('VERSION matcher package.json-versjon', () => {
+    const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8'))
+    expect(VERSION).toBe(pkg.version)
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,8 @@
  * @see README.md for API-referanse og konfigurasjon
  */
 
-export const VERSION = '1.0.0'
+import pkg from '../package.json'
+export const VERSION = pkg.version
 
 // API-klient
 export { createApiClient, ApiError } from './api/apiClient'


### PR DESCRIPTION
Fixes #71

Erstatter hardkodet `VERSION = '1.0.0'` i `src/index.ts` med import fra `package.json`, slik at versjonsnummeret alltid er i sync med pakken.

**Test lagt til**: `VERSION matcher package.json-versjon` i `config-exports.test.ts` verifiserer dette fremover.