### PR TITLE
Fix #80: legg til onSessionError-callback i AuthProviderConfig

### DIFF
--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -617,6 +617,109 @@ describe('createAuthProvider', () => {
     expect(screen.getByTestId('auth').textContent).toBe('false')
   })
 
+  it('onSessionError kalles ved nettverksfeil under initial mount', async () => {
+    const networkError = new Error('Network failure')
+    vi.mocked(mockClient.request).mockRejectedValue(networkError)
+
+    const onSessionError = vi.fn()
+
+    const { AuthProvider, useAuth } = createAuthProvider<TestUser>({
+      apiClient: mockClient,
+      onSessionError,
+    })
+
+    function TestComponent() {
+      const { isAuthenticated, isLoading } = useAuth()
+      return (
+        <div>
+          <span data-testid="loading">{String(isLoading)}</span>
+          <span data-testid="auth">{String(isAuthenticated)}</span>
+        </div>
+      )
+    }
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    expect(screen.getByTestId('auth').textContent).toBe('false')
+    expect(onSessionError).toHaveBeenCalledOnce()
+    expect(onSessionError).toHaveBeenCalledWith(networkError)
+  })
+
+  it('onSessionError kalles ikke ved 401 (forventet uautentisert tilstand)', async () => {
+    vi.mocked(mockClient.request).mockRejectedValue(
+      new ApiError('Unauthorized', 401, 'Unauthorized')
+    )
+
+    const onSessionError = vi.fn()
+
+    const { AuthProvider, useAuth } = createAuthProvider<TestUser>({
+      apiClient: mockClient,
+      onSessionError,
+    })
+
+    function TestComponent() {
+      const { isAuthenticated, isLoading } = useAuth()
+      return (
+        <div>
+          <span data-testid="loading">{String(isLoading)}</span>
+          <span data-testid="auth">{String(isAuthenticated)}</span>
+        </div>
+      )
+    }
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    expect(screen.getByTestId('auth').textContent).toBe('false')
+    expect(onSessionError).not.toHaveBeenCalled()
+  })
+
+  it('uten onSessionError: nettverksfeil kaster ikke feil og setter isAuthenticated=false', async () => {
+    vi.mocked(mockClient.request).mockRejectedValue(new Error('Network failure'))
+
+    const { AuthProvider, useAuth } = createAuthProvider<TestUser>({
+      apiClient: mockClient,
+      // onSessionError ikke oppgitt
+    })
+
+    function TestComponent() {
+      const { isAuthenticated, isLoading } = useAuth()
+      return (
+        <div>
+          <span data-testid="loading">{String(isLoading)}</span>
+          <span data-testid="auth">{String(isAuthenticated)}</span>
+        </div>
+      )
+    }
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false')
+    })
+
+    expect(screen.getByTestId('auth').textContent).toBe('false')
+  })
+
   it('unmount under pågående fetchUser produserer ikke feil etter resolve', async () => {
     let resolveMe: ((value: TestUser) => void) | undefined
 

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -60,6 +60,8 @@ export interface AuthProviderConfig<TUser> extends AuthApiConfig {
   onLogout?: () => void
   /** Custom parsing av brukerdata fra /me- eller /session-endepunktet */
   parseUser?: (data: unknown) => TUser
+  /** Kalles ved uventet feil under sessjonssjekk (ikke 401) */
+  onSessionError?: (error: unknown) => void
   /**
    * Bruk session-endepunkt (2xx for både anonyme og autentiserte) i stedet for
    * /me (som returnerer 401 for anonyme og logger nettverksfeil i konsollen).
@@ -84,6 +86,7 @@ export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
   const {
     apiClient,
     onLogout: onLogoutCallback,
+    onSessionError,
     parseUser,
     useSessionEndpoint,
     ...authApiConfig
@@ -122,8 +125,8 @@ export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
         if (error instanceof ApiError && error.is(401)) {
           setUser(null)
         } else {
-          // Andre feil (nettverksfeil etc.) — sett user til null
           setUser(null)
+          onSessionError?.(error)
         }
       }
     }, [])


### PR DESCRIPTION
Fixes #80

Legger til valgfri `onSessionError?: (error: unknown) => void` i `AuthProviderConfig` slik at konsumentapper kan skille mellom forventet uautentisert tilstand (401) og uventede sesjonsfeil (nettverksfeil/5xx).

**Endringer**:
- `AuthProviderConfig`: nytt valgfritt felt `onSessionError`
- `createAuthProvider`: destrukturerer og kaller `onSessionError?.(error)` i else-grenen av catch
- 3 nye tester: callback kalles ved nettverksfeil, kalles ikke ved 401, ingen feil uten callback