### PR TITLE
Fix #79: formDataRequest retry-logikk via felles fetchWithRetry-hjelpefunksjon

### DIFF
--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -517,6 +517,39 @@ describe('retry', () => {
 // Test 8: formDataRequest
 // ============================================================
 describe('formDataRequest', () => {
+  it('retries ved 503 og lykkes på andre forsøk', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponse({ error: 'Service Unavailable' }, 503, 'Service Unavailable'))
+      .mockResolvedValueOnce(mockResponse({ uploaded: true }))
+
+    const client = createApiClient({ retryCount: 1, retryDelay: 0 })
+    const result = await client.formDataRequest<{ uploaded: boolean }>('/upload', new FormData())
+
+    expect(result).toEqual({ uploaded: true })
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries ved nettverksfeil og lykkes på andre forsøk', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(mockResponse({ uploaded: true }))
+
+    const client = createApiClient({ retryCount: 1, retryDelay: 0 })
+    const result = await client.formDataRequest<{ uploaded: boolean }>('/upload', new FormData())
+
+    expect(result).toEqual({ uploaded: true })
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('gjør ikke retry med retryCount: 0 (default)', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ error: 'Service Unavailable' }, 503, 'Service Unavailable'))
+
+    const client = createApiClient({ retryDelay: 0 })
+
+    await expect(client.formDataRequest('/upload', new FormData())).rejects.toBeInstanceOf(ApiError)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
   it('sender FormData uten Content-Type header', async () => {
     mockFetch.mockResolvedValueOnce(mockResponse({ uploaded: true }))
 

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -194,35 +194,14 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
     }
   }
 
-  async function request<T>(path: string, options?: RequestOptions): Promise<T> {
-    const method = (options?.method ?? 'GET').toUpperCase()
-    const headers: Record<string, string> = { ...options?.headers }
-    const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1
-
-    // CSRF-token på muterende requests
-    if (!SAFE_METHODS.has(method)) {
-      const token = getCsrfToken()
-      if (token) {
-        headers[csrfHeaderName] = token
-      }
-    }
-
-    // Content-Type og body-serialisering
-    let body: string | undefined
-    if (options?.body !== undefined) {
-      headers['Content-Type'] = 'application/json'
-      body = JSON.stringify(options.body)
-    }
-
+  async function fetchWithRetry<T>(
+    fn: () => Promise<Response>,
+    maxAttempts: number
+  ): Promise<T> {
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       let response: Response
       try {
-        response = await fetch(`${basePath}${path}`, {
-          method,
-          headers,
-          body,
-          credentials: 'include',
-        })
+        response = await fn()
       } catch (err) {
         const networkError = new ApiError(
           err instanceof TypeError ? 'Nettverksfeil — sjekk tilkoblingen' : String(err),
@@ -252,6 +231,32 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
     throw new ApiError('Nettverksfeil — sjekk tilkoblingen', 0, 'NetworkError')
   }
 
+  async function request<T>(path: string, options?: RequestOptions): Promise<T> {
+    const method = (options?.method ?? 'GET').toUpperCase()
+    const headers: Record<string, string> = { ...options?.headers }
+    const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1
+
+    // CSRF-token på muterende requests
+    if (!SAFE_METHODS.has(method)) {
+      const token = getCsrfToken()
+      if (token) {
+        headers[csrfHeaderName] = token
+      }
+    }
+
+    // Content-Type og body-serialisering
+    let body: string | undefined
+    if (options?.body !== undefined) {
+      headers['Content-Type'] = 'application/json'
+      body = JSON.stringify(options.body)
+    }
+
+    return fetchWithRetry<T>(
+      () => fetch(`${basePath}${path}`, { method, headers, body, credentials: 'include' }),
+      maxAttempts
+    )
+  }
+
   async function formDataRequest<T>(
     path: string,
     formData: FormData,
@@ -267,27 +272,16 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
     }
 
     // Ikke sett Content-Type — nettleseren setter multipart boundary selv
-    let response: Response
-    try {
-      response = await fetch(`${basePath}${path}`, {
+    // Retry alltid basert på retryCount: filopplastninger er sårbare for transiente nettverksfeil
+    return fetchWithRetry<T>(
+      () => fetch(`${basePath}${path}`, {
         method: upperMethod,
         headers,
         body: formData,
         credentials: 'include',
-      })
-    } catch (err) {
-      throw new ApiError(
-        err instanceof TypeError ? 'Nettverksfeil — sjekk tilkoblingen' : String(err),
-        0,
-        'NetworkError'
-      )
-    }
-
-    if (!response.ok) {
-      return handleErrorResponse(response)
-    }
-
-    return parseResponse<T>(response)
+      }),
+      1 + retryCount
+    )
   }
 
   return {


### PR DESCRIPTION
Fixes #79

## Hva ble gjort

Extraherte retry-løkken fra `request()` til en intern `fetchWithRetry()`-hjelpefunksjon (closure i `createApiClient`), og bruker den i begge funksjoner.

`formDataRequest` bruker nå `1 + retryCount` som maxAttempts — opplastninger er spesielt sårbare for transiente nettverksfeil og dette gir config-feltet faktisk effekt.

## Tester lagt til

- `formDataRequest` med `retryCount: 1` og 503 → 200 (lykkes på retry)
- `formDataRequest` med `retryCount: 1` og nettverksfeil → 200 (lykkes på retry)
- `retryCount: 0` (default) → ingen retry for formDataRequest