### PR TITLE
docs: document onSessionError callback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ npm run lint      # ESLint
 - Generisk User-type: `AuthProvider<TUser>`
 - `loginPath`: f.eks. `/logg-inn`
 - `onLogout`: callback
+- `onSessionError`: callback for uventede sesjonsfeil (network/5xx, ikke 401)
 
 ### ProtectedRoute
 - `loginPath`: konfigurerbar

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ const { AuthProvider, useAuth, ProtectedRoute } = createAuthProvider<MyUser>({
   apiClient: api,                         // API-klient fra createApiClient()
   loginPath: '/logg-inn',                 // Sti til innloggingsside (default: '/login')
   onLogout: () => queryClient.clear(),    // Callback ved utlogging
+  onSessionError: (error) => {            // Callback for uventede sesjonsfeil (network/5xx)
+    logErrorToServer(error)               // Kalles når sessjonssjekk feiler (ikke 401)
+  },
   parseUser: (data) => data as MyUser,    // Custom parsing av /me-respons
   // Unngå 401-logging i konsollen (krever at backend returnerer 2xx på /auth/session):
   useSessionEndpoint: true,               // Bruk session-endepunkt i stedet for /me
@@ -176,6 +179,11 @@ Backend må da returnere 2xx med `{ authenticated: boolean, user?: TUser }`
 slik at nettleseren ikke logger 401-nettverksfeil i konsollen for anonyme
 brukere (Lighthouse `errors-in-console`). `getMe` beholdes uendret for
 bakoverkompatibilitet.
+
+**`onSessionError`** — valgfri callback som kalles når sessjonssjekk feiler med
+en *uventet* feil (nettverksfeil, 5xx osv.). Kalles IKKE på 401 (som er forventet
+og betyr at brukeren ikke er innlogget). Brukes til å loggføre eller håndtere
+feil som bør få oppmerksomhet:
 
 ```ts
 // Autentisert respons
@@ -359,6 +367,8 @@ import {
 | `relativeTime(date)` | `new Date(Date.now() - 7200000)` | `2 timer siden` |
 
 Alle funksjoner returnerer tankestrek (`–`) for ugyldig input.
+
+**Viktig:** Modulen cacher Intl-instanser modul-globalt for ytelse og er designet for single-locale browser-miljøer (`nb-NO`). For SSR med per-request locale kreves refaktor til factory-funksjoner. Ved testing med stubbed `Intl` bruker du `vi.resetModules()` + dynamisk import for å isolere modulen per test.
 
 ---
 


### PR DESCRIPTION
## Summary
- Documents the `onSessionError` callback added in 74f2c9e (closes the docs gap)
- CLAUDE.md: bullet under AuthProvider config section
- README.md: example usage in `createAuthProvider` config + dedicated paragraph distinguishing `onSessionError` from 401-handling
- README.md: SSR/test-time caveat for the `formattering` Intl-cache module

No code changes. Pure documentation.

## Bakgrunn
Disse doc-tilleggene har ligget uncommitted lokalt på `~/git/grunnmur-frontend` og blokkert deploy-workflowens `git pull` på grunnmur-libs i alle 5 forbruker-apper (warning: «grunnmur lib grunnmur-frontend pull failed»). Ved å lande disse blir lokal arbeidstrre ren igjen og pull-fasen i deploy-workflowene blir stabil.

## Test plan
- [ ] CI (lint/test) grønn på denne PR
- [ ] Auto-merge tar PR til main
- [ ] Neste smart-casual/lo-finans/biologportal/6810/styreportal-deploy viser INGEN «grunnmur-frontend pull failed» i annotasjoner