### PR TITLE
docs: legg til useSessionEndpoint og sessionEndpoint i CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ npm run lint      # ESLint
 - `loginPath`: f.eks. `/logg-inn`
 - `onLogout`: callback
 - `onSessionError`: callback for uventede sesjonsfeil (network/5xx, ikke 401)
+- `useSessionEndpoint`: flagg — bruk `/auth/session` i stedet for `/me` ved initial sjekk
+- `sessionEndpoint`: konfigurerbar URL for session-endepunkt (default `/auth/session`)
 
 ### ProtectedRoute
 - `loginPath`: konfigurerbar


### PR DESCRIPTION
Fixes #92

Legger til to manglende konfig-punkter i §AuthContext i CLAUDE.md:
- `useSessionEndpoint`: flagg for bruk av `/auth/session` ved initial sesjonssjekk
- `sessionEndpoint`: konfigurerbar URL (default `/auth/session`)

`onSessionError` var allerede dokumentert.