### PR TITLE
Fix #96: legg til reset-knapp i ErrorBoundary standard fallback

### DIFF
--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -73,14 +73,27 @@ describe('ErrorBoundary', () => {
     expect(onError.mock.calls[0][1]).toHaveProperty('componentStack')
   })
 
-  it('bruker standard fallback-melding uten fallback-prop', () => {
+  it('standard fallback viser reset-knapp som nullstiller feilen', async () => {
+    const { fireEvent } = await import('@testing-library/react')
+    let shouldThrow = true
+
+    function ConditionalThrow() {
+      if (shouldThrow) throw new Error('Uventet feil')
+      return <p>Gjenopprettet</p>
+    }
+
     render(
       <ErrorBoundary>
-        <ThrowingComponent error={new Error('Uventet feil')} />
+        <ConditionalThrow />
       </ErrorBoundary>
     )
+
     expect(screen.getByText('Noe gikk galt')).toBeDefined()
-    expect(screen.getByText('Last inn siden på nytt')).toBeDefined()
+    const resetBtn = screen.getByRole('button', { name: 'Last inn på nytt' })
+    expect(resetBtn).toBeDefined()
+    shouldThrow = false
+    fireEvent.click(resetBtn)
+    expect(screen.getByText('Gjenopprettet')).toBeDefined()
   })
 
   it('setter className på wrapper-elementet', () => {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -83,11 +83,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       } else if (fallback !== undefined) {
         content = fallback
       } else {
-        // Standard fallback-melding
         content = (
           <>
             <p>Noe gikk galt</p>
-            <p>Last inn siden på nytt</p>
+            <button type="button" onClick={this.reset}>Last inn på nytt</button>
           </>
         )
       }


### PR DESCRIPTION
Fixes #96

## Endringer
- Standard fallback (ingen `fallback`-prop satt) viser nå en klikkbar knapp i stedet for statisk tekst
- Knappen kaller `reset()` internt og lar React re-rendre children uten full sidereload
- Test oppdatert: verifiserer at knappen finnes, at klikk nullstiller feilstatus og at children rendres på nytt