### PR TITLE
feat: analytics module (Umami) — AnalyticsProvider, useAnalytics, TrackClick, usePageView

### DIFF
--- a/src/analytics/AnalyticsProvider.test.tsx
+++ b/src/analytics/AnalyticsProvider.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { AnalyticsProvider } from './AnalyticsProvider'
+
+describe('AnalyticsProvider', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.stubEnv('DEV', false)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllEnvs()
+    // Rydd opp script-tags som kan være lagt til
+    document.head.querySelectorAll('script[data-website-id]').forEach(s => s.remove())
+  })
+
+  it('script-tag legges IKKE til når localStorage umami.disabled er 1', () => {
+    localStorage.setItem('umami.disabled', '1')
+
+    render(
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <div>innhold</div>
+      </AnalyticsProvider>
+    )
+
+    const scripts = document.head.querySelectorAll('script[data-website-id]')
+    expect(scripts.length).toBe(0)
+  })
+
+  it('script-tag legges IKKE til i dev-modus (DEV=true)', () => {
+    vi.stubEnv('DEV', true)
+
+    render(
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <div>innhold</div>
+      </AnalyticsProvider>
+    )
+
+    const scripts = document.head.querySelectorAll('script[data-website-id]')
+    expect(scripts.length).toBe(0)
+  })
+
+  it('script-tag legges til i produksjonsmodus uten opt-out', () => {
+    render(
+      <AnalyticsProvider websiteId="prod-id" scriptSrc="https://analytics.example.com/script.js">
+        <div>innhold</div>
+      </AnalyticsProvider>
+    )
+
+    const scripts = document.head.querySelectorAll('script[data-website-id="prod-id"]')
+    expect(scripts.length).toBe(1)
+    expect((scripts[0] as HTMLScriptElement).src).toBe('https://analytics.example.com/script.js')
+  })
+
+  it('rendrer children uavhengig av tracking-tilstand', () => {
+    localStorage.setItem('umami.disabled', '1')
+
+    const { getByText } = render(
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <p>Barn-innhold</p>
+      </AnalyticsProvider>
+    )
+
+    expect(getByText('Barn-innhold')).toBeDefined()
+  })
+})

--- a/src/analytics/AnalyticsProvider.tsx
+++ b/src/analytics/AnalyticsProvider.tsx
@@ -1,0 +1,88 @@
+/**
+ * AnalyticsProvider — laster Umami analytics-skriptet og eksponerer
+ * tracking-tilstand via React Context.
+ *
+ * Skipper innlasting i dev-modus (import.meta.env.DEV) eller dersom
+ * brukeren har satt admin opt-out via localStorage.
+ *
+ * @example
+ * ```tsx
+ * <AnalyticsProvider websiteId="abc123" scriptSrc="https://analytics.example.com/script.js">
+ *   <App />
+ * </AnalyticsProvider>
+ * ```
+ */
+
+import { createContext, useContext, useEffect } from 'react'
+import type { ReactNode } from 'react'
+
+// Lokal augmentering av ImportMeta — unngår avhengighet av vite/client i biblioteket.
+// Konsumentenes bundler (Vite) erstatter import.meta.env.DEV ved build.
+declare global {
+  interface ImportMeta {
+    readonly env: {
+      readonly DEV: boolean
+      readonly [key: string]: unknown
+    }
+  }
+}
+
+/** @internal — brukt av useAnalytics og usePageView */
+export interface AnalyticsContextValue {
+  isEnabled: boolean
+}
+
+/** @internal */
+export const AnalyticsContext = createContext<AnalyticsContextValue>({ isEnabled: false })
+
+/** @internal */
+export function useAnalyticsContext(): AnalyticsContextValue {
+  return useContext(AnalyticsContext)
+}
+
+/** Props for AnalyticsProvider */
+export interface AnalyticsProviderProps {
+  /** Umami website ID (data-website-id) */
+  websiteId: string
+  /** URL til Umami script */
+  scriptSrc: string
+  children: ReactNode
+}
+
+function isOptedOut(): boolean {
+  try {
+    return localStorage.getItem('umami.disabled') === '1'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Laster Umami analytics-skriptet og tilgjengeliggjør tracking via kontekst.
+ */
+export function AnalyticsProvider({ websiteId, scriptSrc, children }: AnalyticsProviderProps) {
+  const isEnabled = !import.meta.env.DEV && !isOptedOut()
+
+  useEffect(() => {
+    if (!isEnabled) return
+
+    const script = document.createElement('script')
+    script.async = true
+    script.defer = true
+    script.setAttribute('data-website-id', websiteId)
+    script.src = scriptSrc
+    document.head.appendChild(script)
+
+    return () => {
+      if (document.head.contains(script)) {
+        document.head.removeChild(script)
+      }
+    }
+  }, [isEnabled, websiteId, scriptSrc])
+
+  return (
+    <AnalyticsContext.Provider value={{ isEnabled }}>
+      {children}
+    </AnalyticsContext.Provider>
+  )
+}

--- a/src/analytics/TrackClick.tsx
+++ b/src/analytics/TrackClick.tsx
@@ -1,0 +1,48 @@
+/**
+ * TrackClick — deklarativ wrapper som sporer klikk på barnelementet.
+ *
+ * @example
+ * ```tsx
+ * <TrackClick event="cta.opprett-mote">
+ *   <Button>Opprett møte</Button>
+ * </TrackClick>
+ * ```
+ */
+
+import { cloneElement, isValidElement } from 'react'
+import type { MouseEvent, ReactElement, ReactNode } from 'react'
+import { useAnalytics } from './useAnalytics'
+
+/** Props for TrackClick */
+export interface TrackClickProps {
+  /** Navn på eventet som spores ved klikk */
+  event: string
+  /** Valgfrie event-data */
+  data?: Record<string, unknown>
+  children: ReactNode
+}
+
+type ClickableProps = {
+  onClick?: (e: MouseEvent) => void
+  [key: string]: unknown
+}
+
+/**
+ * Injiserer trackEvent i barnelementets onClick-handler.
+ * Er barnelementet ikke et React-element, rendres det uten sporing.
+ */
+export function TrackClick({ event, data, children }: TrackClickProps) {
+  const { trackEvent } = useAnalytics()
+
+  if (!isValidElement(children)) return <>{children}</>
+
+  const child = children as ReactElement<ClickableProps>
+  const originalOnClick = child.props.onClick
+
+  return cloneElement(child, {
+    onClick: (e: MouseEvent) => {
+      trackEvent(event, data)
+      originalOnClick?.(e)
+    },
+  } as Partial<ClickableProps>)
+}

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -1,0 +1,9 @@
+export { AnalyticsProvider } from './AnalyticsProvider'
+export type { AnalyticsProviderProps } from './AnalyticsProvider'
+
+export { useAnalytics } from './useAnalytics'
+
+export { TrackClick } from './TrackClick'
+export type { TrackClickProps } from './TrackClick'
+
+export { usePageView } from './usePageView'

--- a/src/analytics/useAnalytics.test.tsx
+++ b/src/analytics/useAnalytics.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act, cleanup } from '@testing-library/react'
+import { useAnalytics } from './useAnalytics'
+import { AnalyticsProvider } from './AnalyticsProvider'
+
+function TestComponent({ onTrack }: { onTrack: (name: string) => void }) {
+  const { trackEvent } = useAnalytics()
+  return (
+    <button onClick={() => {
+      trackEvent('test-event', { key: 'val' })
+      onTrack('test-event')
+    }}>
+      spor
+    </button>
+  )
+}
+
+describe('useAnalytics', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllEnvs()
+    // Rydd opp window.umami-mock
+    delete (window as Window & { umami?: unknown }).umami
+  })
+
+  it('trackEvent er no-op når window.umami er undefined', async () => {
+    vi.stubEnv('DEV', false)
+    const onTrack = vi.fn()
+
+    const { getByText } = render(
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <TestComponent onTrack={onTrack} />
+      </AnalyticsProvider>
+    )
+
+    // window.umami er ikke satt — kallet skal ikke kaste feil
+    await act(async () => {
+      getByText('spor').click()
+    })
+
+    expect(onTrack).toHaveBeenCalledOnce()
+    // Ingen feil kastet = no-op fungerer korrekt
+  })
+
+  it('trackEvent kaller window.umami.track når umami er tilgjengelig', async () => {
+    vi.stubEnv('DEV', false)
+    const mockTrack = vi.fn()
+    ;(window as Window & { umami?: { track: typeof mockTrack } }).umami = { track: mockTrack }
+
+    const onTrack = vi.fn()
+
+    const { getByText } = render(
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <TestComponent onTrack={onTrack} />
+      </AnalyticsProvider>
+    )
+
+    await act(async () => {
+      getByText('spor').click()
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith('test-event', { key: 'val' })
+  })
+
+  it('trackEvent er no-op utenfor AnalyticsProvider (context-default isEnabled=false)', async () => {
+    vi.stubEnv('DEV', false)
+    const mockTrack = vi.fn()
+    ;(window as Window & { umami?: { track: typeof mockTrack } }).umami = { track: mockTrack }
+
+    const onTrack = vi.fn()
+
+    // Ingen AnalyticsProvider — context-default er isEnabled=false
+    const { getByText } = render(<TestComponent onTrack={onTrack} />)
+
+    await act(async () => {
+      getByText('spor').click()
+    })
+
+    // window.umami.track skal IKKE kalles siden isEnabled=false
+    expect(mockTrack).not.toHaveBeenCalled()
+    expect(onTrack).toHaveBeenCalledOnce()
+  })
+
+  it('trackEvent er no-op i dev-modus (DEV=true)', async () => {
+    vi.stubEnv('DEV', true)
+    const mockTrack = vi.fn()
+    ;(window as Window & { umami?: { track: typeof mockTrack } }).umami = { track: mockTrack }
+
+    const onTrack = vi.fn()
+
+    const { getByText } = render(
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <TestComponent onTrack={onTrack} />
+      </AnalyticsProvider>
+    )
+
+    await act(async () => {
+      getByText('spor').click()
+    })
+
+    expect(mockTrack).not.toHaveBeenCalled()
+  })
+})

--- a/src/analytics/useAnalytics.ts
+++ b/src/analytics/useAnalytics.ts
@@ -1,0 +1,40 @@
+/**
+ * useAnalytics — hook for manuell event-sporing via Umami.
+ *
+ * @example
+ * ```tsx
+ * const { trackEvent } = useAnalytics()
+ * trackEvent('cta.klikk', { side: 'hjem' })
+ * ```
+ */
+
+import { useCallback } from 'react'
+import { useAnalyticsContext } from './AnalyticsProvider'
+
+declare global {
+  interface Window {
+    umami?: {
+      track(eventName: string, eventData?: Record<string, unknown>): void
+      track(viewProperties: { url?: string; title?: string }): void
+    }
+  }
+}
+
+/**
+ * Returnerer trackEvent-funksjon for manuell event-sporing.
+ *
+ * Er no-op dersom tracking er deaktivert (DEV-modus, opt-out, eller utenfor AnalyticsProvider).
+ */
+export function useAnalytics() {
+  const { isEnabled } = useAnalyticsContext()
+
+  const trackEvent = useCallback(
+    (name: string, data?: Record<string, unknown>) => {
+      if (!isEnabled) return
+      window.umami?.track(name, data)
+    },
+    [isEnabled]
+  )
+
+  return { trackEvent }
+}

--- a/src/analytics/usePageView.ts
+++ b/src/analytics/usePageView.ts
@@ -1,0 +1,31 @@
+/**
+ * usePageView — sporer SPA-sidevisninger ved navigasjon med React Router.
+ *
+ * Krever at komponenten er innenfor en react-router-dom Router.
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   usePageView()
+ *   return <Routes>...</Routes>
+ * }
+ * ```
+ */
+
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useAnalyticsContext } from './AnalyticsProvider'
+
+/**
+ * Kaller window.umami.track ved pathname-endringer.
+ * Er no-op dersom tracking er deaktivert.
+ */
+export function usePageView(): void {
+  const { isEnabled } = useAnalyticsContext()
+  const location = useLocation()
+
+  useEffect(() => {
+    if (!isEnabled) return
+    window.umami?.track({ url: location.pathname })
+  }, [isEnabled, location.pathname])
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,3 +36,11 @@ export {
   formatFileSize,
   relativeTime
 } from './lib/formatters'
+
+// Analytics
+export { AnalyticsProvider } from './analytics/AnalyticsProvider'
+export type { AnalyticsProviderProps } from './analytics/AnalyticsProvider'
+export { useAnalytics } from './analytics/useAnalytics'
+export { TrackClick } from './analytics/TrackClick'
+export type { TrackClickProps } from './analytics/TrackClick'
+export { usePageView } from './analytics/usePageView'


### PR DESCRIPTION
Fixes #99

## Summary
- Ny `src/analytics/` modul med Umami self-hosted analytics-integrasjon
- `AnalyticsProvider` laster script lazy, skipper ved `import.meta.env.DEV` og `localStorage.umami.disabled=1`
- `useAnalytics()` hook med null-safe `trackEvent()` wrapper rundt `window.umami`
- `TrackClick` deklarativ click-wrapper via `cloneElement`
- `usePageView()` React Router-aware SPA-navigasjonssporing
- 8 nye tester (opt-out, DEV-skip, no-op uten provider, window.umami null-guard)

## Test plan
- [x] `AnalyticsProvider` — script ikke lastet ved localStorage opt-out
- [x] `AnalyticsProvider` — script ikke lastet i DEV-modus
- [x] `AnalyticsProvider` — script lastet i produksjonsmodus uten opt-out
- [x] `useAnalytics` — trackEvent no-op uten window.umami
- [x] `useAnalytics` — trackEvent kaller window.umami.track
- [x] `useAnalytics` — trackEvent no-op utenfor AnalyticsProvider
- [x] `useAnalytics` — trackEvent no-op i DEV-modus
- [x] Full testsuite: 147/147 grønn

🤖 Generated with [Claude Code](https://claude.com/claude-code)