### PR TITLE
fix: tighten analytics module (post-QA: TrackClick typing, https warning, tests)

### DIFF
--- a/src/analytics/AnalyticsProvider.tsx
+++ b/src/analytics/AnalyticsProvider.tsx
@@ -66,6 +66,10 @@ export function AnalyticsProvider({ websiteId, scriptSrc, children }: AnalyticsP
   useEffect(() => {
     if (!isEnabled) return
 
+    if (!scriptSrc.startsWith('https://')) {
+      console.warn('[Analytics] scriptSrc bør bruke https://', scriptSrc)
+    }
+
     const script = document.createElement('script')
     script.async = true
     script.defer = true

--- a/src/analytics/TrackClick.test.tsx
+++ b/src/analytics/TrackClick.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act, cleanup } from '@testing-library/react'
+import { TrackClick } from './TrackClick'
+import { AnalyticsProvider } from './AnalyticsProvider'
+
+describe('TrackClick', () => {
+  beforeEach(() => {
+    vi.stubEnv('DEV', false)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllEnvs()
+    delete (window as Window & { umami?: unknown }).umami
+  })
+
+  it('kaller trackEvent og originalOnClick ved klikk', async () => {
+    const mockTrack = vi.fn()
+    ;(window as Window & { umami?: { track: typeof mockTrack } }).umami = { track: mockTrack }
+
+    const originalClick = vi.fn()
+
+    const { getByText } = render(
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <TrackClick event="btn.klikk" data={{ side: 'hjem' }}>
+          <button onClick={originalClick}>Klikk meg</button>
+        </TrackClick>
+      </AnalyticsProvider>
+    )
+
+    await act(async () => {
+      getByText('Klikk meg').click()
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith('btn.klikk', { side: 'hjem' })
+    expect(originalClick).toHaveBeenCalledOnce()
+  })
+
+  it('krasjer ikke når barn ikke har onClick', async () => {
+    const mockTrack = vi.fn()
+    ;(window as Window & { umami?: { track: typeof mockTrack } }).umami = { track: mockTrack }
+
+    const { getByText } = render(
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <TrackClick event="btn.klikk">
+          <button>Ingen onClick</button>
+        </TrackClick>
+      </AnalyticsProvider>
+    )
+
+    await act(async () => {
+      getByText('Ingen onClick').click()
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith('btn.klikk', undefined)
+  })
+
+  it('rendrer ikke-React-element-barn uten sporing', () => {
+    const { getByText } = render(
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <TrackClick event="test">ren tekst</TrackClick>
+      </AnalyticsProvider>
+    )
+
+    expect(getByText('ren tekst')).toBeDefined()
+  })
+
+  it('sporer ikke klikk i DEV-modus', async () => {
+    vi.stubEnv('DEV', true)
+    const mockTrack = vi.fn()
+    ;(window as Window & { umami?: { track: typeof mockTrack } }).umami = { track: mockTrack }
+
+    const { getByText } = render(
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <TrackClick event="btn.klikk">
+          <button>Klikk</button>
+        </TrackClick>
+      </AnalyticsProvider>
+    )
+
+    await act(async () => {
+      getByText('Klikk').click()
+    })
+
+    expect(mockTrack).not.toHaveBeenCalled()
+  })
+})

--- a/src/analytics/TrackClick.tsx
+++ b/src/analytics/TrackClick.tsx
@@ -22,10 +22,7 @@ export interface TrackClickProps {
   children: ReactNode
 }
 
-type ClickableProps = {
-  onClick?: (e: MouseEvent) => void
-  [key: string]: unknown
-}
+type ClickableElement = ReactElement<{ onClick?: (e: MouseEvent) => void }>
 
 /**
  * Injiserer trackEvent i barnelementets onClick-handler.
@@ -36,7 +33,7 @@ export function TrackClick({ event, data, children }: TrackClickProps) {
 
   if (!isValidElement(children)) return <>{children}</>
 
-  const child = children as ReactElement<ClickableProps>
+  const child = children as ClickableElement
   const originalOnClick = child.props.onClick
 
   return cloneElement(child, {
@@ -44,5 +41,5 @@ export function TrackClick({ event, data, children }: TrackClickProps) {
       trackEvent(event, data)
       originalOnClick?.(e)
     },
-  } as Partial<ClickableProps>)
+  })
 }

--- a/src/analytics/usePageView.test.tsx
+++ b/src/analytics/usePageView.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act, cleanup } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom'
+import { usePageView } from './usePageView'
+import { AnalyticsProvider } from './AnalyticsProvider'
+
+function PageViewTracker() {
+  usePageView()
+  return null
+}
+
+function NavigateButton({ to }: { to: string }) {
+  const navigate = useNavigate()
+  return <button onClick={() => navigate(to)}>naviger</button>
+}
+
+function TestApp() {
+  return (
+    <MemoryRouter initialEntries={['/']}>
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <PageViewTracker />
+        <Routes>
+          <Route path="*" element={<NavigateButton to="/om-oss" />} />
+        </Routes>
+      </AnalyticsProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('usePageView', () => {
+  beforeEach(() => {
+    vi.stubEnv('DEV', false)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllEnvs()
+    delete (window as Window & { umami?: unknown }).umami
+  })
+
+  it('kaller window.umami.track ved mount med initial pathname', () => {
+    const mockTrack = vi.fn()
+    ;(window as Window & { umami?: { track: typeof mockTrack } }).umami = { track: mockTrack }
+
+    render(<TestApp />)
+
+    expect(mockTrack).toHaveBeenCalledWith({ url: '/' })
+  })
+
+  it('kaller window.umami.track på nytt ved navigasjon', async () => {
+    const mockTrack = vi.fn()
+    ;(window as Window & { umami?: { track: typeof mockTrack } }).umami = { track: mockTrack }
+
+    const { getByText } = render(<TestApp />)
+
+    await act(async () => {
+      getByText('naviger').click()
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith({ url: '/om-oss' })
+  })
+
+  it('kaller IKKE window.umami.track i DEV-modus', () => {
+    vi.stubEnv('DEV', true)
+    const mockTrack = vi.fn()
+    ;(window as Window & { umami?: { track: typeof mockTrack } }).umami = { track: mockTrack }
+
+    render(<TestApp />)
+
+    expect(mockTrack).not.toHaveBeenCalled()
+  })
+
+  it('krasjer ikke når window.umami er undefined', () => {
+    expect(() => render(<TestApp />)).not.toThrow()
+  })
+})


### PR DESCRIPTION
Post-QA follow-up for #99.

## Summary
- `TrackClick`: fjernet `[key: string]: unknown` index-signatur fra ClickableProps — typen er nå smalere og tryggere med React 19
- `AnalyticsProvider`: `console.warn` hvis `scriptSrc` ikke bruker `https://`
- Nye tester: `TrackClick.test.tsx` (4 tester) og `usePageView.test.tsx` (4 tester)

## Test plan
- [x] TrackClick: trackEvent + originalOnClick kalles ved klikk
- [x] TrackClick: krasjer ikke uten onClick på barn
- [x] TrackClick: rendrer ren tekst uten sporing
- [x] TrackClick: ingen sporing i DEV-modus
- [x] usePageView: track kalles på initial pathname
- [x] usePageView: track kalles på navigasjon
- [x] usePageView: ingen sporing i DEV-modus
- [x] usePageView: krasjer ikke uten window.umami
- [x] Full testsuite: 155/155 grønn

🤖 Generated with [Claude Code](https://claude.com/claude-code)