### PR TITLE
feat(analytics): legg til identify() og reset() i useAnalytics

### DIFF
--- a/src/analytics/useAnalytics.test.tsx
+++ b/src/analytics/useAnalytics.test.tsx
@@ -2,8 +2,8 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, act, cleanup } from '@testing-library/react'
-import { useAnalytics } from './useAnalytics'
+import { render, act, cleanup, waitFor } from '@testing-library/react'
+import { useAnalytics, hashUserId } from './useAnalytics'
 import { AnalyticsProvider } from './AnalyticsProvider'
 
 function TestComponent({ onTrack }: { onTrack: (name: string) => void }) {
@@ -102,5 +102,150 @@ describe('useAnalytics', () => {
     })
 
     expect(mockTrack).not.toHaveBeenCalled()
+  })
+
+  describe('hashUserId', () => {
+    it('genererer 16-tegns hex-pseudonym', async () => {
+      const hash = await hashUserId('user-123', 'app.example.com')
+      expect(hash).toMatch(/^[0-9a-f]{16}$/)
+    })
+
+    it('samme input gir samme hash', async () => {
+      const h1 = await hashUserId('user-123', 'app.example.com')
+      const h2 = await hashUserId('user-123', 'app.example.com')
+      expect(h1).toBe(h2)
+    })
+
+    it('forskjellig salt gir forskjellig hash (cross-app-isolasjon)', async () => {
+      const a = await hashUserId('user-123', 'app-a.example.com')
+      const b = await hashUserId('user-123', 'app-b.example.com')
+      expect(a).not.toBe(b)
+    })
+  })
+
+  describe('identify', () => {
+    function IdentifyComponent({
+      userId,
+      attrs,
+    }: {
+      userId: string | number | null
+      attrs?: Record<string, unknown>
+    }) {
+      const { identify } = useAnalytics()
+      return (
+        <button onClick={() => identify(userId, attrs)}>identify</button>
+      )
+    }
+
+    it('kaller window.umami.identify med hashet id + attrs', async () => {
+      vi.stubEnv('DEV', false)
+      const mockIdentify = vi.fn()
+      ;(window as Window & { umami?: { track: () => void; identify: typeof mockIdentify } }).umami = {
+        track: vi.fn(),
+        identify: mockIdentify,
+      }
+
+      const { getByText } = render(
+        <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+          <IdentifyComponent userId={42} attrs={{ rolle: 'ADMIN', tenant: 't1' }} />
+        </AnalyticsProvider>
+      )
+
+      await act(async () => {
+        getByText('identify').click()
+      })
+
+      await waitFor(() => expect(mockIdentify).toHaveBeenCalledOnce())
+      const [id, attrs] = mockIdentify.mock.calls[0]
+      expect(id).toMatch(/^[0-9a-f]{16}$/)
+      expect(attrs).toEqual({ rolle: 'ADMIN', tenant: 't1' })
+    })
+
+    it('userId=null kaller identify({}) for å rydde session', async () => {
+      vi.stubEnv('DEV', false)
+      const mockIdentify = vi.fn()
+      ;(window as Window & { umami?: { track: () => void; identify: typeof mockIdentify } }).umami = {
+        track: vi.fn(),
+        identify: mockIdentify,
+      }
+
+      const { getByText } = render(
+        <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+          <IdentifyComponent userId={null} />
+        </AnalyticsProvider>
+      )
+
+      await act(async () => {
+        getByText('identify').click()
+      })
+
+      expect(mockIdentify).toHaveBeenCalledWith({})
+    })
+
+    it('er no-op i dev-modus', async () => {
+      vi.stubEnv('DEV', true)
+      const mockIdentify = vi.fn()
+      ;(window as Window & { umami?: { track: () => void; identify: typeof mockIdentify } }).umami = {
+        track: vi.fn(),
+        identify: mockIdentify,
+      }
+
+      const { getByText } = render(
+        <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+          <IdentifyComponent userId={1} />
+        </AnalyticsProvider>
+      )
+
+      await act(async () => {
+        getByText('identify').click()
+      })
+
+      expect(mockIdentify).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('reset', () => {
+    function ResetComponent() {
+      const { reset } = useAnalytics()
+      return <button onClick={() => reset()}>reset</button>
+    }
+
+    it('kaller window.umami.identify({}) for å rydde session', async () => {
+      vi.stubEnv('DEV', false)
+      const mockIdentify = vi.fn()
+      ;(window as Window & { umami?: { track: () => void; identify: typeof mockIdentify } }).umami = {
+        track: vi.fn(),
+        identify: mockIdentify,
+      }
+
+      const { getByText } = render(
+        <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+          <ResetComponent />
+        </AnalyticsProvider>
+      )
+
+      await act(async () => {
+        getByText('reset').click()
+      })
+
+      expect(mockIdentify).toHaveBeenCalledWith({})
+    })
+
+    it('er no-op når isEnabled=false (utenfor provider)', async () => {
+      vi.stubEnv('DEV', false)
+      const mockIdentify = vi.fn()
+      ;(window as Window & { umami?: { track: () => void; identify: typeof mockIdentify } }).umami = {
+        track: vi.fn(),
+        identify: mockIdentify,
+      }
+
+      const { getByText } = render(<ResetComponent />)
+
+      await act(async () => {
+        getByText('reset').click()
+      })
+
+      expect(mockIdentify).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/analytics/useAnalytics.ts
+++ b/src/analytics/useAnalytics.ts
@@ -1,10 +1,18 @@
 /**
- * useAnalytics — hook for manuell event-sporing via Umami.
+ * useAnalytics — hook for manuell event-sporing og session-identifisering via Umami.
  *
  * @example
  * ```tsx
- * const { trackEvent } = useAnalytics()
+ * const { trackEvent, identify, reset } = useAnalytics()
+ *
+ * // Event-sporing:
  * trackEvent('cta.klikk', { side: 'hjem' })
+ *
+ * // Session-identifisering ved login:
+ * await identify(user.id, { rolle: user.role, tenant: 'leienbiolog' })
+ *
+ * // Rydd ved logout:
+ * reset()
  * ```
  */
 
@@ -16,14 +24,35 @@ declare global {
     umami?: {
       track(eventName: string, eventData?: Record<string, unknown>): void
       track(viewProperties: { url?: string; title?: string }): void
+      identify(uniqueId: string, sessionData?: Record<string, unknown>): void
+      identify(sessionData: Record<string, unknown>): void
     }
   }
 }
 
 /**
- * Returnerer trackEvent-funksjon for manuell event-sporing.
+ * Hash en bruker-ID til et pseudonym (16 hex-tegn) via SHA-256.
  *
- * Er no-op dersom tracking er deaktivert (DEV-modus, opt-out, eller utenfor AnalyticsProvider).
+ * Salt er per-app (default = window.location.hostname) slik at samme bruker
+ * får ulike pseudonymer på tvers av apper — forhindrer cross-app-tracking.
+ *
+ * @internal
+ */
+export async function hashUserId(userId: string, salt?: string): Promise<string> {
+  const effectiveSalt = salt ?? (typeof window !== 'undefined' ? window.location.hostname : '')
+  const data = new TextEncoder().encode(`${userId}:${effectiveSalt}`)
+  const hash = await crypto.subtle.digest('SHA-256', data)
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .substring(0, 16)
+}
+
+/**
+ * Returnerer trackEvent, identify og reset for analytics.
+ *
+ * Alle funksjoner er no-op dersom tracking er deaktivert (DEV-modus,
+ * opt-out, eller utenfor AnalyticsProvider).
  */
 export function useAnalytics() {
   const { isEnabled } = useAnalyticsContext()
@@ -36,5 +65,35 @@ export function useAnalytics() {
     [isEnabled]
   )
 
-  return { trackEvent }
+  /**
+   * Kobler nåværende Umami-sesjon til en stabil pseudonym-ID + valgfrie
+   * session-attributter (typisk rolle og tenant).
+   *
+   * Bruker-ID hashes lokalt før den sendes til Umami — Umami ser aldri
+   * den faktiske ID-en eller noen PII.
+   */
+  const identify = useCallback(
+    async (userId: string | number | null, attrs?: Record<string, unknown>) => {
+      if (!isEnabled || !window.umami) return
+      if (userId === null) {
+        window.umami.identify(attrs ?? {})
+        return
+      }
+      const id = await hashUserId(String(userId))
+      window.umami.identify(id, attrs ?? {})
+    },
+    [isEnabled]
+  )
+
+  /**
+   * Tøm session-identifisering — kall ved logout for å forhindre at
+   * neste bruker på samme nettleser arver forrige bruker sin Umami-sesjon.
+   * (Særlig viktig på delte PC-er, f.eks. styremøter.)
+   */
+  const reset = useCallback(() => {
+    if (!isEnabled || !window.umami) return
+    window.umami.identify({})
+  }, [isEnabled])
+
+  return { trackEvent, identify, reset }
 }


### PR DESCRIPTION
## Summary

Lar konsumenter koble Umami-sesjon til en pseudonymisert bruker-ID slik at det blir mulig å skille mellom innloggede brukere i analytics-data uten å avsløre PII til Umami.

## API

```ts
const { trackEvent, identify, reset } = useAnalytics()

// Ved login
await identify(user.id, { rolle: user.role, tenant: 'leienbiolog' })

// Ved logout
reset()
```

## Personvern

- **Bruker-ID hashes lokalt** med SHA-256 (16 hex-tegn pseudonym). Umami ser aldri ID-en eller noen PII.
- **Per-app salt** (default = `window.location.hostname`) → samme bruker får ulikt pseudonym på tvers av apper, ingen cross-app-tracking.
- **`reset()` ved logout** er kritisk — ellers arver neste bruker på samme nettleser session (særlig delte styre-PCer).
- Alle funksjoner gates på `isEnabled` (DEV/opt-out/utenfor provider).

## Tester

12 nye tester (utvidet fra 4):
- `hashUserId`: determinisme, per-salt-isolasjon, format
- `identify`: hashed id + attrs, null = ryd, dev-modus = no-op
- `reset`: kaller identify({}), gated på isEnabled

Totalt: 163 tester grønne.

Refs misc-scripts plan #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)