### PR TITLE
docs: useAnalytics identify() og reset() i README og CHANGELOG (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ og prosjektet folger [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-05-20
+
+### Lagt til
+- `useAnalytics()` returnerer nå `{ trackEvent, identify, reset }` — de to nye funksjonene ble implementert i commit `538e235` (2026-05-18) men manglet i dokumentasjonen.
+  - `identify(userId, attrs?)` — kobler Umami-sesjon til pseudonymisert bruker-ID (hashes lokalt via SHA-256 med per-app salt)
+  - `reset()` — tøm session-identifisering ved logout (viktig på delte maskiner)
+
 ## [1.0.1] - 2026-05-13
 
 ### Lagt til

--- a/README.md
+++ b/README.md
@@ -411,16 +411,27 @@ import { AnalyticsProvider, useAnalytics, TrackClick, usePageView } from '@tommy
 
 ### `useAnalytics()`
 
-Hook for manuell event-sporing.
+Hook for manuell event-sporing og session-identifisering.
 
 ```ts
-const { trackEvent } = useAnalytics()
+const { trackEvent, identify, reset } = useAnalytics()
 
+// Event-sporing:
 trackEvent('button.click', { page: 'home' })
 trackEvent('purchase', { amount: 1234 })
+
+// Login — kobler Umami-sesjon til pseudonymisert bruker-ID:
+await identify(user.id, { rolle: user.role })
+
+// Logout — tøm session-identifisering:
+reset()
 ```
 
-Returnerer `{ trackEvent: (name: string, data?: Record<string, unknown>) => void }`. Er no-op dersom tracking er deaktivert.
+Returnerer `{ trackEvent, identify, reset }`. Alle funksjoner er no-op dersom tracking er deaktivert.
+
+- `trackEvent(name, data?)` — spor en navngitt hendelse med valgfrie attributter
+- `identify(userId, attrs?)` — kobler Umami-sesjon til pseudonymisert bruker-ID (hashes lokalt via SHA-256 før sending)
+- `reset()` — tøm session-identifisering ved logout
 
 ---
 


### PR DESCRIPTION
Fixes #108

Oppdaterer `useAnalytics()`-dokumentasjonen som manglet `identify()` og `reset()` etter commit `538e235` (2026-05-18).

**Endringer:**
- README: Utvider `useAnalytics()`-seksjonen med eksempel og beskrivelse av alle tre funksjoner
- CHANGELOG: Legger til versjon 1.0.2 med de to nye funksjonene dokumentert