### PR TITLE
fix: update brace-expansion 5.0.5→5.0.6 (GHSA-jxxr-4gwj-5jf2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixes #116

Oppdaterer  fra 5.0.5 til 5.0.6 i .

Transitiv avhengighet via  / . Ikke direkte i  — ren lockfile-oppdatering.

- found 0 vulnerabilities bekrefter 0 sårbarheter etter oppdatering
- Alle 169 eksisterende tester passerer