### PR TITLE
Fix #122: bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tommyskogstad/frontend-core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Felles frontend-bibliotek for Kotlin/Ktor-apper",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Fixes #122

Synchronizes package.json version with CHANGELOG.md, which already had 1.0.2 documented from commit 3464533.

- package.json: 1.0.1 → 1.0.2
- Tests: All passing (VERSION matches package.json)
- No breaking changes