### PR TITLE
docs: update TypeScript version to 6.0+ and add missing consumer apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Tilsvarer `grunnmur` (Kotlin-bibliotek) for backend, men for React/TypeScript fr
 
 ## Teknologier
 
-- **Språk**: TypeScript 5.7+
+- **Språk**: TypeScript 6.0+
 - **Framework**: React 18/19
 - **Test**: Vitest + Testing Library
 - **Publisering**: GitHub Packages (privat, @tommyskogstad scope)
@@ -69,6 +69,9 @@ npm run lint      # ESLint
 | 6810 | In-memory CSRF |
 | styreportal | Multi-tenant (TenantContext) |
 | biologportal | React Query, TOTP, Observer-rolle |
+| maskemester | Claude API-integrasjon, strikkekalkulator |
+| vinforalle | Quiz og anbefalinger |
+| smart-casual | Under oppstart |
 
 ## Konvensjoner
 


### PR DESCRIPTION
Fixes #124

## Endringer
- Oppdaterer «TypeScript 5.7+» → «TypeScript 6.0+» i Teknologier-seksjonen (package.json bruker `^6.0.3`)
- Legger til maskemester, vinforalle og smart-casual i konsumentapp-tabellen