### PR TITLE
docs(analytics): legg isDev til i AnalyticsProvider JSDoc-eksempel (#129 QA)

### DIFF
--- a/src/analytics/AnalyticsProvider.tsx
+++ b/src/analytics/AnalyticsProvider.tsx
@@ -7,7 +7,11 @@
  *
  * @example
  * ```tsx
- * <AnalyticsProvider websiteId="abc123" scriptSrc="https://analytics.example.com/script.js">
+ * <AnalyticsProvider
+ *   websiteId="abc123"
+ *   scriptSrc="https://analytics.example.com/script.js"
+ *   isDev={import.meta.env.DEV}
+ * >
  *   <App />
  * </AnalyticsProvider>
  * ```


### PR DESCRIPTION
QA-funn fra #129: JSDoc-eksempelet manglet -prop.