### PR TITLE
refactor(analytics): extract context to analyticsContext.ts (#128)

### DIFF
--- a/src/analytics/AnalyticsProvider.tsx
+++ b/src/analytics/AnalyticsProvider.tsx
@@ -13,21 +13,9 @@
  * ```
  */
 
-import { createContext, useContext, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
-
-/** @internal — brukt av useAnalytics og usePageView */
-export interface AnalyticsContextValue {
-  isEnabled: boolean
-}
-
-/** @internal */
-export const AnalyticsContext = createContext<AnalyticsContextValue>({ isEnabled: false })
-
-/** @internal */
-export function useAnalyticsContext(): AnalyticsContextValue {
-  return useContext(AnalyticsContext)
-}
+import { AnalyticsContext } from './analyticsContext'
 
 /** Props for AnalyticsProvider */
 export interface AnalyticsProviderProps {

--- a/src/analytics/analyticsContext.ts
+++ b/src/analytics/analyticsContext.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react'
+
+/** @internal — brukt av useAnalytics og usePageView */
+export interface AnalyticsContextValue {
+  isEnabled: boolean
+}
+
+/** @internal */
+export const AnalyticsContext = createContext<AnalyticsContextValue>({ isEnabled: false })
+
+/** @internal */
+export function useAnalyticsContext(): AnalyticsContextValue {
+  return useContext(AnalyticsContext)
+}

--- a/src/analytics/useAnalytics.ts
+++ b/src/analytics/useAnalytics.ts
@@ -17,7 +17,7 @@
  */
 
 import { useCallback } from 'react'
-import { useAnalyticsContext } from './AnalyticsProvider'
+import { useAnalyticsContext } from './analyticsContext'
 
 declare global {
   interface Window {

--- a/src/analytics/usePageView.ts
+++ b/src/analytics/usePageView.ts
@@ -14,7 +14,7 @@
 
 import { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
-import { useAnalyticsContext } from './AnalyticsProvider'
+import { useAnalyticsContext } from './analyticsContext'
 
 /**
  * Kaller window.umami.track ved pathname-endringer.

--- a/src/config/__tests__/config-exports.test.ts
+++ b/src/config/__tests__/config-exports.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync, existsSync } from 'fs'
 import { resolve } from 'path'
 import { VERSION } from '../../index'
+import * as indexExports from '../../index'
 
 const ROOT = resolve(__dirname, '..', '..', '..')
 
@@ -99,6 +100,26 @@ describe('VERSION er synkronisert med package.json', () => {
   it('VERSION matcher package.json-versjon', () => {
     const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8'))
     expect(VERSION).toBe(pkg.version)
+  })
+})
+
+describe('Analytics interne symboler er ikke i public API', () => {
+  it('useAnalyticsContext er ikke eksportert fra index', () => {
+    expect('useAnalyticsContext' in indexExports).toBe(false)
+  })
+
+  it('AnalyticsContext er ikke eksportert fra index', () => {
+    expect('AnalyticsContext' in indexExports).toBe(false)
+  })
+
+  it('AnalyticsContext er ikke eksportert fra AnalyticsProvider-modulen', async () => {
+    const mod = await import('../../analytics/AnalyticsProvider')
+    expect('AnalyticsContext' in mod).toBe(false)
+  })
+
+  it('useAnalyticsContext er ikke eksportert fra AnalyticsProvider-modulen', async () => {
+    const mod = await import('../../analytics/AnalyticsProvider')
+    expect('useAnalyticsContext' in mod).toBe(false)
   })
 })
 


### PR DESCRIPTION
Fixes #128

## Hva ble gjort
- Opprettet `src/analytics/analyticsContext.ts` med `AnalyticsContextValue`, `AnalyticsContext` og `useAnalyticsContext` (intern fil, ikke re-eksportert fra `index.ts`)
- `AnalyticsProvider.tsx` er nå en ren komponentfil — importerer kontekst internt fra `./analyticsContext`
- `useAnalytics.ts` og `usePageView.ts` oppdatert til å importere fra `./analyticsContext`
- Negative assertions lagt til i `config-exports.test.ts` for å verifisere at `AnalyticsContext` og `useAnalyticsContext` ikke lekker ut i public API

## Resultat
- Ingen ESLint react-refresh-advarsler i analytics-modulen
- HMR vil nå hot-swap `AnalyticsProvider` isolert (ren komponentfil)
- Interne kontekst-symboler ikke lenger tilgjengelige via deep import