### PR TITLE
Fix #133: commit dist/ to git — eliminerer stale-type-feil i konsumentapper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/** linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-dist/
 *.tgz
 .env
 .env.local

--- a/dist/analytics/AnalyticsProvider.d.ts
+++ b/dist/analytics/AnalyticsProvider.d.ts
@@ -1,0 +1,36 @@
+/**
+ * AnalyticsProvider — laster Umami analytics-skriptet og eksponerer
+ * tracking-tilstand via React Context.
+ *
+ * Skipper innlasting i dev-modus (import.meta.env.DEV) eller dersom
+ * brukeren har satt admin opt-out via localStorage.
+ *
+ * @example
+ * ```tsx
+ * <AnalyticsProvider
+ *   websiteId="abc123"
+ *   scriptSrc="https://analytics.example.com/script.js"
+ *   isDev={import.meta.env.DEV}
+ * >
+ *   <App />
+ * </AnalyticsProvider>
+ * ```
+ */
+import type { ReactNode } from 'react';
+/** Props for AnalyticsProvider */
+export interface AnalyticsProviderProps {
+    /** Umami website ID (data-website-id) */
+    websiteId: string;
+    /** URL til Umami script */
+    scriptSrc: string;
+    /**
+     * Om appen kjøres i dev-modus. Sett til `import.meta.env.DEV` i konsumentappen.
+     * Når `true` lastes ikke analytics-skriptet. Default `false`.
+     */
+    isDev?: boolean;
+    children: ReactNode;
+}
+/**
+ * Laster Umami analytics-skriptet og tilgjengeliggjør tracking via kontekst.
+ */
+export declare function AnalyticsProvider({ websiteId, scriptSrc, isDev, children }: AnalyticsProviderProps): import("react/jsx-runtime").JSX.Element;

--- a/dist/analytics/AnalyticsProvider.js
+++ b/dist/analytics/AnalyticsProvider.js
@@ -1,0 +1,55 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+/**
+ * AnalyticsProvider — laster Umami analytics-skriptet og eksponerer
+ * tracking-tilstand via React Context.
+ *
+ * Skipper innlasting i dev-modus (import.meta.env.DEV) eller dersom
+ * brukeren har satt admin opt-out via localStorage.
+ *
+ * @example
+ * ```tsx
+ * <AnalyticsProvider
+ *   websiteId="abc123"
+ *   scriptSrc="https://analytics.example.com/script.js"
+ *   isDev={import.meta.env.DEV}
+ * >
+ *   <App />
+ * </AnalyticsProvider>
+ * ```
+ */
+import { useEffect, useState } from 'react';
+import { AnalyticsContext } from './analyticsContext';
+function isOptedOut() {
+    try {
+        return localStorage.getItem('umami.disabled') === '1';
+    }
+    catch {
+        return false;
+    }
+}
+/**
+ * Laster Umami analytics-skriptet og tilgjengeliggjør tracking via kontekst.
+ */
+export function AnalyticsProvider({ websiteId, scriptSrc, isDev = false, children }) {
+    const [optedOut] = useState(() => isOptedOut());
+    const isEnabled = !isDev && !optedOut;
+    useEffect(() => {
+        if (!isEnabled)
+            return;
+        if (!scriptSrc.startsWith('https://')) {
+            console.warn('[Analytics] scriptSrc bør bruke https://', scriptSrc);
+        }
+        const script = document.createElement('script');
+        script.async = true;
+        script.defer = true;
+        script.setAttribute('data-website-id', websiteId);
+        script.src = scriptSrc;
+        document.head.appendChild(script);
+        return () => {
+            if (document.head.contains(script)) {
+                document.head.removeChild(script);
+            }
+        };
+    }, [isEnabled, websiteId, scriptSrc]);
+    return (_jsx(AnalyticsContext.Provider, { value: { isEnabled }, children: children }));
+}

--- a/dist/analytics/TrackClick.d.ts
+++ b/dist/analytics/TrackClick.d.ts
@@ -1,0 +1,24 @@
+/**
+ * TrackClick — deklarativ wrapper som sporer klikk på barnelementet.
+ *
+ * @example
+ * ```tsx
+ * <TrackClick event="cta.opprett-mote">
+ *   <Button>Opprett møte</Button>
+ * </TrackClick>
+ * ```
+ */
+import type { ReactNode } from 'react';
+/** Props for TrackClick */
+export interface TrackClickProps {
+    /** Navn på eventet som spores ved klikk */
+    event: string;
+    /** Valgfrie event-data */
+    data?: Record<string, unknown>;
+    children: ReactNode;
+}
+/**
+ * Injiserer trackEvent i barnelementets onClick-handler.
+ * Er barnelementet ikke et React-element, rendres det uten sporing.
+ */
+export declare function TrackClick({ event, data, children }: TrackClickProps): import("react/jsx-runtime").JSX.Element;

--- a/dist/analytics/TrackClick.js
+++ b/dist/analytics/TrackClick.js
@@ -1,0 +1,30 @@
+import { Fragment as _Fragment, jsx as _jsx } from "react/jsx-runtime";
+/**
+ * TrackClick — deklarativ wrapper som sporer klikk på barnelementet.
+ *
+ * @example
+ * ```tsx
+ * <TrackClick event="cta.opprett-mote">
+ *   <Button>Opprett møte</Button>
+ * </TrackClick>
+ * ```
+ */
+import { cloneElement, isValidElement } from 'react';
+import { useAnalytics } from './useAnalytics';
+/**
+ * Injiserer trackEvent i barnelementets onClick-handler.
+ * Er barnelementet ikke et React-element, rendres det uten sporing.
+ */
+export function TrackClick({ event, data, children }) {
+    const { trackEvent } = useAnalytics();
+    if (!isValidElement(children))
+        return _jsx(_Fragment, { children: children });
+    const child = children;
+    const originalOnClick = child.props.onClick;
+    return cloneElement(child, {
+        onClick: (e) => {
+            trackEvent(event, data);
+            originalOnClick?.(e);
+        },
+    });
+}

--- a/dist/analytics/analyticsContext.d.ts
+++ b/dist/analytics/analyticsContext.d.ts
@@ -1,0 +1,8 @@
+/** @internal — brukt av useAnalytics og usePageView */
+export interface AnalyticsContextValue {
+    isEnabled: boolean;
+}
+/** @internal */
+export declare const AnalyticsContext: import("react").Context<AnalyticsContextValue>;
+/** @internal */
+export declare function useAnalyticsContext(): AnalyticsContextValue;

--- a/dist/analytics/analyticsContext.js
+++ b/dist/analytics/analyticsContext.js
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+/** @internal */
+export const AnalyticsContext = createContext({ isEnabled: false });
+/** @internal */
+export function useAnalyticsContext() {
+    return useContext(AnalyticsContext);
+}

--- a/dist/analytics/index.d.ts
+++ b/dist/analytics/index.d.ts
@@ -1,0 +1,6 @@
+export { AnalyticsProvider } from './AnalyticsProvider';
+export type { AnalyticsProviderProps } from './AnalyticsProvider';
+export { useAnalytics } from './useAnalytics';
+export { TrackClick } from './TrackClick';
+export type { TrackClickProps } from './TrackClick';
+export { usePageView } from './usePageView';

--- a/dist/analytics/index.js
+++ b/dist/analytics/index.js
@@ -1,0 +1,4 @@
+export { AnalyticsProvider } from './AnalyticsProvider';
+export { useAnalytics } from './useAnalytics';
+export { TrackClick } from './TrackClick';
+export { usePageView } from './usePageView';

--- a/dist/analytics/useAnalytics.d.ts
+++ b/dist/analytics/useAnalytics.d.ts
@@ -1,0 +1,50 @@
+/**
+ * useAnalytics — hook for manuell event-sporing og session-identifisering via Umami.
+ *
+ * @example
+ * ```tsx
+ * const { trackEvent, identify, reset } = useAnalytics()
+ *
+ * // Event-sporing:
+ * trackEvent('cta.klikk', { side: 'hjem' })
+ *
+ * // Session-identifisering ved login:
+ * await identify(user.id, { rolle: user.role, tenant: 'leienbiolog' })
+ *
+ * // Rydd ved logout:
+ * reset()
+ * ```
+ */
+declare global {
+    interface Window {
+        umami?: {
+            track(eventName: string, eventData?: Record<string, unknown>): void;
+            track(viewProperties: {
+                url?: string;
+                title?: string;
+            }): void;
+            identify(uniqueId: string, sessionData?: Record<string, unknown>): void;
+            identify(sessionData: Record<string, unknown>): void;
+        };
+    }
+}
+/**
+ * Hash en bruker-ID til et pseudonym (16 hex-tegn) via SHA-256.
+ *
+ * Salt er per-app (default = window.location.hostname) slik at samme bruker
+ * får ulike pseudonymer på tvers av apper — forhindrer cross-app-tracking.
+ *
+ * @internal
+ */
+export declare function hashUserId(userId: string, salt?: string): Promise<string>;
+/**
+ * Returnerer trackEvent, identify og reset for analytics.
+ *
+ * Alle funksjoner er no-op dersom tracking er deaktivert (DEV-modus,
+ * opt-out, eller utenfor AnalyticsProvider).
+ */
+export declare function useAnalytics(): {
+    trackEvent: (name: string, data?: Record<string, unknown>) => void;
+    identify: (userId: string | number | null, attrs?: Record<string, unknown>) => Promise<void>;
+    reset: () => void;
+};

--- a/dist/analytics/useAnalytics.js
+++ b/dist/analytics/useAnalytics.js
@@ -1,0 +1,78 @@
+/**
+ * useAnalytics — hook for manuell event-sporing og session-identifisering via Umami.
+ *
+ * @example
+ * ```tsx
+ * const { trackEvent, identify, reset } = useAnalytics()
+ *
+ * // Event-sporing:
+ * trackEvent('cta.klikk', { side: 'hjem' })
+ *
+ * // Session-identifisering ved login:
+ * await identify(user.id, { rolle: user.role, tenant: 'leienbiolog' })
+ *
+ * // Rydd ved logout:
+ * reset()
+ * ```
+ */
+import { useCallback } from 'react';
+import { useAnalyticsContext } from './analyticsContext';
+/**
+ * Hash en bruker-ID til et pseudonym (16 hex-tegn) via SHA-256.
+ *
+ * Salt er per-app (default = window.location.hostname) slik at samme bruker
+ * får ulike pseudonymer på tvers av apper — forhindrer cross-app-tracking.
+ *
+ * @internal
+ */
+export async function hashUserId(userId, salt) {
+    const effectiveSalt = salt ?? (typeof window !== 'undefined' ? window.location.hostname : '');
+    const data = new TextEncoder().encode(`${userId}:${effectiveSalt}`);
+    const hash = await crypto.subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(hash))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('')
+        .substring(0, 16);
+}
+/**
+ * Returnerer trackEvent, identify og reset for analytics.
+ *
+ * Alle funksjoner er no-op dersom tracking er deaktivert (DEV-modus,
+ * opt-out, eller utenfor AnalyticsProvider).
+ */
+export function useAnalytics() {
+    const { isEnabled } = useAnalyticsContext();
+    const trackEvent = useCallback((name, data) => {
+        if (!isEnabled)
+            return;
+        window.umami?.track(name, data);
+    }, [isEnabled]);
+    /**
+     * Kobler nåværende Umami-sesjon til en stabil pseudonym-ID + valgfrie
+     * session-attributter (typisk rolle og tenant).
+     *
+     * Bruker-ID hashes lokalt før den sendes til Umami — Umami ser aldri
+     * den faktiske ID-en eller noen PII.
+     */
+    const identify = useCallback(async (userId, attrs) => {
+        if (!isEnabled || !window.umami)
+            return;
+        if (userId === null) {
+            window.umami.identify(attrs ?? {});
+            return;
+        }
+        const id = await hashUserId(String(userId));
+        window.umami.identify(id, attrs ?? {});
+    }, [isEnabled]);
+    /**
+     * Tøm session-identifisering — kall ved logout for å forhindre at
+     * neste bruker på samme nettleser arver forrige bruker sin Umami-sesjon.
+     * (Særlig viktig på delte PC-er, f.eks. styremøter.)
+     */
+    const reset = useCallback(() => {
+        if (!isEnabled || !window.umami)
+            return;
+        window.umami.identify({});
+    }, [isEnabled]);
+    return { trackEvent, identify, reset };
+}

--- a/dist/analytics/usePageView.d.ts
+++ b/dist/analytics/usePageView.d.ts
@@ -1,0 +1,18 @@
+/**
+ * usePageView — sporer SPA-sidevisninger ved navigasjon med React Router.
+ *
+ * Krever at komponenten er innenfor en react-router-dom Router.
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   usePageView()
+ *   return <Routes>...</Routes>
+ * }
+ * ```
+ */
+/**
+ * Kaller window.umami.track ved pathname-endringer.
+ * Er no-op dersom tracking er deaktivert.
+ */
+export declare function usePageView(): void;

--- a/dist/analytics/usePageView.js
+++ b/dist/analytics/usePageView.js
@@ -1,0 +1,29 @@
+/**
+ * usePageView — sporer SPA-sidevisninger ved navigasjon med React Router.
+ *
+ * Krever at komponenten er innenfor en react-router-dom Router.
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   usePageView()
+ *   return <Routes>...</Routes>
+ * }
+ * ```
+ */
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useAnalyticsContext } from './analyticsContext';
+/**
+ * Kaller window.umami.track ved pathname-endringer.
+ * Er no-op dersom tracking er deaktivert.
+ */
+export function usePageView() {
+    const { isEnabled } = useAnalyticsContext();
+    const location = useLocation();
+    useEffect(() => {
+        if (!isEnabled)
+            return;
+        window.umami?.track({ url: location.pathname });
+    }, [isEnabled, location.pathname]);
+}

--- a/dist/api/apiClient.d.ts
+++ b/dist/api/apiClient.d.ts
@@ -1,0 +1,75 @@
+/**
+ * Konfigurerbar API-klient for Kotlin/Ktor-apper.
+ *
+ * Håndterer CSRF-tokens (cookie eller in-memory), JSON-serialisering,
+ * 401-deduplisering og FormData-opplasting.
+ *
+ * @example
+ * ```ts
+ * const api = createApiClient({
+ *   onUnauthorized: (error) => window.location.href = '/logg-inn',
+ * })
+ *
+ * const users = await api.request<User[]>('/users')
+ * await api.request('/users', { method: 'POST', body: { name: 'Ola' } })
+ * ```
+ */
+/** Konfigurasjon for API-klienten */
+export interface ApiClientConfig {
+    /** URL-prefiks for alle requests (default: '/api') */
+    basePath?: string;
+    /** Hvor CSRF-token hentes fra (default: 'cookie') */
+    csrfSource?: 'cookie' | 'memory';
+    /** Navn på CSRF-cookie (default: 'csrf_token') */
+    csrfCookieName?: string;
+    /** Navn på CSRF-header (default: 'X-CSRF-Token') */
+    csrfHeaderName?: string;
+    /**
+     * Kalles ved 401-respons. Mottar ApiError-objektet.
+     * Har innebygd deduplisering — kalles maks én gang inntil resetUnauthorizedFlag().
+     */
+    onUnauthorized?: (error: ApiError) => void;
+    /** Antall automatiske retries ved nettverksfeil eller 5xx (default: 0) */
+    retryCount?: number;
+    /** Grunnforsinkelse mellom retries i ms — dobles eksponentielt (default: 500) */
+    retryDelay?: number;
+}
+/** Alternativer for enkeltrequest */
+export interface RequestOptions {
+    /** HTTP-metode (default: 'GET') */
+    method?: string;
+    /** Request-body — serialiseres automatisk til JSON */
+    body?: unknown;
+    /** Ekstra headers */
+    headers?: Record<string, string>;
+}
+/** API-klient returnert av createApiClient() */
+export interface ApiClient {
+    /** Generisk request med JSON-serialisering */
+    request: <T>(path: string, options?: RequestOptions) => Promise<T>;
+    /** FormData-request for filopplasting */
+    formDataRequest: <T>(path: string, formData: FormData, method?: string) => Promise<T>;
+    /** Hent gjeldende CSRF-token */
+    getCsrfToken: () => string | null;
+    /** Sett CSRF-token manuelt (for memory-mode) */
+    setCsrfToken: (token: string) => void;
+    /** Resett 401-deduplisering (kall etter re-autentisering) */
+    resetUnauthorizedFlag: () => void;
+}
+/** Strukturert feilklasse for API-feil */
+export declare class ApiError extends Error {
+    readonly status: number;
+    readonly statusText: string;
+    readonly body?: Record<string, unknown> | undefined;
+    readonly name = "ApiError";
+    constructor(message: string, status: number, statusText: string, body?: Record<string, unknown> | undefined);
+    /** Sjekk om feilen er en spesifikk HTTP-statuskode */
+    is(status: number): boolean;
+}
+/**
+ * Opprett en konfigurerbar API-klient.
+ *
+ * @param config - Valgfri konfigurasjon
+ * @returns API-klient med request, formDataRequest, getCsrfToken, setCsrfToken
+ */
+export declare function createApiClient(config?: ApiClientConfig): ApiClient;

--- a/dist/api/apiClient.js
+++ b/dist/api/apiClient.js
@@ -1,0 +1,197 @@
+/**
+ * Konfigurerbar API-klient for Kotlin/Ktor-apper.
+ *
+ * Håndterer CSRF-tokens (cookie eller in-memory), JSON-serialisering,
+ * 401-deduplisering og FormData-opplasting.
+ *
+ * @example
+ * ```ts
+ * const api = createApiClient({
+ *   onUnauthorized: (error) => window.location.href = '/logg-inn',
+ * })
+ *
+ * const users = await api.request<User[]>('/users')
+ * await api.request('/users', { method: 'POST', body: { name: 'Ola' } })
+ * ```
+ */
+/** Strukturert feilklasse for API-feil */
+export class ApiError extends Error {
+    constructor(message, status, statusText, body) {
+        super(message);
+        this.status = status;
+        this.statusText = statusText;
+        this.body = body;
+        this.name = 'ApiError';
+    }
+    /** Sjekk om feilen er en spesifikk HTTP-statuskode */
+    is(status) {
+        return this.status === status;
+    }
+}
+/** HTTP-metoder som IKKE er muterende og ikke trenger CSRF-token */
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+function shouldRetryStatus(status) {
+    return status >= 500 || status === 429;
+}
+function getRetryAfterMs(response) {
+    const header = response.headers.get('Retry-After');
+    if (!header)
+        return null;
+    const seconds = parseInt(header, 10);
+    return isNaN(seconds) ? null : seconds * 1000;
+}
+/**
+ * Les en cookie-verdi fra document.cookie.
+ * Bruker korrekt regex-mønster med decodeURIComponent.
+ */
+function getCookieValue(name) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${escaped}=([^;]*)`));
+    return match ? decodeURIComponent(match[1]) : null;
+}
+/**
+ * Opprett en konfigurerbar API-klient.
+ *
+ * @param config - Valgfri konfigurasjon
+ * @returns API-klient med request, formDataRequest, getCsrfToken, setCsrfToken
+ */
+export function createApiClient(config) {
+    const basePath = config?.basePath ?? '/api';
+    const csrfSource = config?.csrfSource ?? 'cookie';
+    const csrfCookieName = config?.csrfCookieName ?? 'csrf_token';
+    const csrfHeaderName = config?.csrfHeaderName ?? 'X-CSRF-Token';
+    const onUnauthorized = config?.onUnauthorized;
+    const retryCount = config?.retryCount ?? 0;
+    const retryDelayBase = config?.retryDelay ?? 500;
+    // In-memory CSRF-token (brukes kun i memory-mode)
+    let memoryCsrfToken = null;
+    // 401-deduplisering
+    let unauthorizedHandled = false;
+    function getCsrfToken() {
+        if (csrfSource === 'memory') {
+            return memoryCsrfToken;
+        }
+        return getCookieValue(csrfCookieName);
+    }
+    function setCsrfToken(token) {
+        memoryCsrfToken = token;
+    }
+    function resetUnauthorizedFlag() {
+        unauthorizedHandled = false;
+    }
+    /**
+     * Håndter feilresponser. Kaster ApiError med parsed body.
+     */
+    async function handleErrorResponse(response) {
+        let body;
+        let message = response.statusText;
+        try {
+            const text = await response.text();
+            if (text) {
+                body = JSON.parse(text);
+                if (typeof body?.message === 'string') {
+                    message = body.message;
+                }
+            }
+        }
+        catch {
+            // Ikke-JSON respons — bruk statusText
+        }
+        const error = new ApiError(message, response.status, response.statusText, body);
+        // 401-håndtering med deduplisering
+        if (response.status === 401 && onUnauthorized && !unauthorizedHandled) {
+            unauthorizedHandled = true;
+            onUnauthorized(error);
+        }
+        throw error;
+    }
+    /**
+     * Parse respons-body. Håndterer tom respons.
+     */
+    async function parseResponse(response) {
+        const text = await response.text();
+        if (!text) {
+            return null;
+        }
+        try {
+            return JSON.parse(text);
+        }
+        catch {
+            throw new ApiError('Ugyldig JSON i respons', response.status, response.statusText);
+        }
+    }
+    async function fetchWithRetry(fn, maxAttempts) {
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            let response;
+            try {
+                response = await fn();
+            }
+            catch (err) {
+                const networkError = new ApiError(err instanceof TypeError ? 'Nettverksfeil — sjekk tilkoblingen' : String(err), 0, 'NetworkError');
+                if (attempt < maxAttempts - 1) {
+                    await sleep(retryDelayBase * Math.pow(2, attempt));
+                    continue;
+                }
+                throw networkError;
+            }
+            if (!response.ok) {
+                if (attempt < maxAttempts - 1 && shouldRetryStatus(response.status)) {
+                    const delay = getRetryAfterMs(response) ?? retryDelayBase * Math.pow(2, attempt);
+                    await sleep(delay);
+                    continue;
+                }
+                return handleErrorResponse(response);
+            }
+            return parseResponse(response);
+        }
+        // Nådd kun hvis maxAttempts er 0 (aldri i praksis siden minimum er 1)
+        throw new ApiError('Nettverksfeil — sjekk tilkoblingen', 0, 'NetworkError');
+    }
+    async function request(path, options) {
+        const method = (options?.method ?? 'GET').toUpperCase();
+        const headers = { ...options?.headers };
+        const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1;
+        // CSRF-token på muterende requests
+        if (!SAFE_METHODS.has(method)) {
+            const token = getCsrfToken();
+            if (token) {
+                headers[csrfHeaderName] = token;
+            }
+        }
+        // Content-Type og body-serialisering
+        let body;
+        if (options?.body !== undefined) {
+            headers['Content-Type'] = 'application/json';
+            body = JSON.stringify(options.body);
+        }
+        return fetchWithRetry(() => fetch(`${basePath}${path}`, { method, headers, body, credentials: 'include' }), maxAttempts);
+    }
+    async function formDataRequest(path, formData, method = 'POST') {
+        const upperMethod = method.toUpperCase();
+        const headers = {};
+        // CSRF-token (FormData er alltid muterende)
+        const token = getCsrfToken();
+        if (token) {
+            headers[csrfHeaderName] = token;
+        }
+        // Ikke sett Content-Type — nettleseren setter multipart boundary selv
+        // Kun POST retries: PUT/PATCH/DELETE er ikke nødvendigvis idempotente
+        const maxFormAttempts = upperMethod === 'POST' ? 1 + retryCount : 1;
+        return fetchWithRetry(() => fetch(`${basePath}${path}`, {
+            method: upperMethod,
+            headers,
+            body: formData,
+            credentials: 'include',
+        }), maxFormAttempts);
+    }
+    return {
+        request,
+        formDataRequest,
+        getCsrfToken,
+        setCsrfToken,
+        resetUnauthorizedFlag,
+    };
+}

--- a/dist/auth/AuthContext.d.ts
+++ b/dist/auth/AuthContext.d.ts
@@ -1,0 +1,79 @@
+/**
+ * Generisk AuthContext med provider og hook for autentisering.
+ *
+ * Bruker createAuthApi() for kommunikasjon og tilbyr en
+ * factory-funksjon createAuthProvider<TUser>() som returnerer
+ * en typet AuthProvider og useAuth-hook.
+ *
+ * @example
+ * ```tsx
+ * interface MyUser { id: number; email: string; role: string }
+ *
+ * const { AuthProvider, useAuth } = createAuthProvider<MyUser>({
+ *   apiClient,
+ *   loginPath: '/logg-inn',
+ *   onLogout: () => queryClient.clear(),
+ * })
+ *
+ * // I app root:
+ * <AuthProvider>
+ *   <App />
+ * </AuthProvider>
+ *
+ * // I komponent:
+ * const { user, isAuthenticated, logout } = useAuth()
+ * ```
+ */
+import type { ReactNode } from 'react';
+import type { ApiClient } from '../api/apiClient';
+import type { AuthApiConfig, LoginResponse } from './authApi';
+import type { ProtectedRouteProps } from '../components/ProtectedRoute';
+/** Verdier eksponert av useAuth() */
+export interface AuthContextValue<TUser> {
+    /** Innlogget bruker, eller null */
+    user: TUser | null;
+    /** Om bruker er autentisert */
+    isAuthenticated: boolean;
+    /** Om initial sessjonssjekk pågår */
+    isLoading: boolean;
+    /** Logg inn med e-post og kode */
+    login: (email: string, code: string) => Promise<LoginResponse>;
+    /** Logg ut */
+    logout: () => Promise<void>;
+    /** Hent brukerinfo på nytt */
+    refreshUser: () => Promise<void>;
+}
+/** Konfigurasjon for createAuthProvider() */
+export interface AuthProviderConfig<TUser> extends AuthApiConfig {
+    /** API-klient fra createApiClient() */
+    apiClient: ApiClient;
+    /** Sti til innloggingsside (default: '/login') */
+    loginPath?: string;
+    /** Callback ved utlogging — f.eks. queryClient.clear() */
+    onLogout?: () => void;
+    /** Custom parsing av brukerdata fra /me- eller /session-endepunktet */
+    parseUser?: (data: unknown) => TUser;
+    /** Kalles ved uventet feil under sessjonssjekk (ikke 401) */
+    onSessionError?: (error: unknown) => void;
+    /**
+     * Bruk session-endepunkt (2xx for både anonyme og autentiserte) i stedet for
+     * /me (som returnerer 401 for anonyme og logger nettverksfeil i konsollen).
+     *
+     * Krever at backend returnerer `{ authenticated: boolean, user?: TUser }` på
+     * `sessionEndpoint` (default: `/auth/session`). Default: false.
+     */
+    useSessionEndpoint?: boolean;
+}
+/**
+ * Opprett en typet AuthProvider og useAuth-hook.
+ *
+ * @param config - Konfigurasjon med apiClient og valgfrie callbacks
+ * @returns Objekt med AuthProvider-komponent og useAuth-hook
+ */
+export declare function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
+    AuthProvider: React.FC<{
+        children: ReactNode;
+    }>;
+    useAuth: () => AuthContextValue<TUser>;
+    ProtectedRoute: React.FC<ProtectedRouteProps<TUser>>;
+};

--- a/dist/auth/AuthContext.js
+++ b/dist/auth/AuthContext.js
@@ -1,0 +1,123 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+/**
+ * Generisk AuthContext med provider og hook for autentisering.
+ *
+ * Bruker createAuthApi() for kommunikasjon og tilbyr en
+ * factory-funksjon createAuthProvider<TUser>() som returnerer
+ * en typet AuthProvider og useAuth-hook.
+ *
+ * @example
+ * ```tsx
+ * interface MyUser { id: number; email: string; role: string }
+ *
+ * const { AuthProvider, useAuth } = createAuthProvider<MyUser>({
+ *   apiClient,
+ *   loginPath: '/logg-inn',
+ *   onLogout: () => queryClient.clear(),
+ * })
+ *
+ * // I app root:
+ * <AuthProvider>
+ *   <App />
+ * </AuthProvider>
+ *
+ * // I komponent:
+ * const { user, isAuthenticated, logout } = useAuth()
+ * ```
+ */
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { ApiError } from '../api/apiClient';
+import { createAuthApi } from './authApi';
+import { createProtectedRoute } from '../components/ProtectedRoute';
+/**
+ * Opprett en typet AuthProvider og useAuth-hook.
+ *
+ * @param config - Konfigurasjon med apiClient og valgfrie callbacks
+ * @returns Objekt med AuthProvider-komponent og useAuth-hook
+ */
+export function createAuthProvider(config) {
+    const { apiClient, onLogout: onLogoutCallback, onSessionError, parseUser, useSessionEndpoint, ...authApiConfig } = config;
+    const authApi = createAuthApi(apiClient, authApiConfig);
+    // Context med undefined som sentinel for "utenfor provider"
+    const AuthContext = createContext(undefined);
+    function AuthProvider({ children }) {
+        const [user, setUser] = useState(null);
+        const [isLoading, setIsLoading] = useState(true);
+        const isMountedRef = useRef(true);
+        const fetchUser = useCallback(async () => {
+            try {
+                if (useSessionEndpoint) {
+                    const session = await authApi.getSession();
+                    if (!isMountedRef.current)
+                        return;
+                    if (!session.authenticated || session.user === undefined) {
+                        setUser(null);
+                        return;
+                    }
+                    const parsed = parseUser ? parseUser(session.user) : session.user;
+                    setUser(parsed);
+                    return;
+                }
+                const data = await authApi.getMe();
+                if (!isMountedRef.current)
+                    return;
+                const parsed = parseUser ? parseUser(data) : data;
+                setUser(parsed);
+            }
+            catch (error) {
+                if (!isMountedRef.current)
+                    return;
+                // 401 betyr at brukeren ikke er innlogget — det er forventet
+                if (error instanceof ApiError && error.is(401)) {
+                    setUser(null);
+                }
+                else {
+                    setUser(null);
+                    onSessionError?.(error);
+                }
+            }
+        }, []);
+        const refreshUser = useCallback(async () => {
+            await fetchUser();
+        }, [fetchUser]);
+        const login = useCallback(async (email, code) => {
+            const response = await authApi.verifyCode(email, code);
+            // Etter vellykket login, hent brukerinfo
+            await fetchUser();
+            apiClient.resetUnauthorizedFlag();
+            return response;
+        }, [fetchUser]);
+        const logout = useCallback(async () => {
+            await authApi.logout();
+            setUser(null);
+            onLogoutCallback?.();
+        }, []); // authApi og onLogoutCallback er factory-scope konstanter, ikke React-tilstand
+        // Sjekk sesjon ved mount — cleanup hindrer state-oppdatering etter unmount
+        useEffect(() => {
+            isMountedRef.current = true;
+            fetchUser().finally(() => {
+                if (isMountedRef.current)
+                    setIsLoading(false);
+            });
+            return () => { isMountedRef.current = false; };
+        }, [fetchUser]);
+        const value = useMemo(() => ({
+            user,
+            isAuthenticated: user !== null,
+            isLoading,
+            login,
+            logout,
+            refreshUser,
+        }), [user, isLoading, login, logout, refreshUser]);
+        return (_jsx(AuthContext.Provider, { value: value, children: children }));
+    }
+    function useAuth() {
+        const context = useContext(AuthContext);
+        if (context === undefined) {
+            throw new Error('useAuth må brukes innenfor en AuthProvider');
+        }
+        return context;
+    }
+    const ProtectedRoute = createProtectedRoute(useAuth);
+    return { AuthProvider, useAuth, ProtectedRoute };
+}

--- a/dist/auth/authApi.d.ts
+++ b/dist/auth/authApi.d.ts
@@ -1,0 +1,64 @@
+/**
+ * Generisk auth-API som bruker apiClient for kommunikasjon.
+ *
+ * Tilbyr requestCode, verifyCode, getMe og logout — felles for alle apper.
+ *
+ * @example
+ * ```ts
+ * const authApi = createAuthApi(apiClient)
+ * await authApi.requestCode('ola@example.com')
+ * const result = await authApi.verifyCode('ola@example.com', '123456')
+ * const user = await authApi.getMe<MyUser>()
+ * await authApi.logout()
+ * ```
+ */
+import type { ApiClient } from '../api/apiClient';
+/** Respons fra verifyCode — inneholder eventuelt CSRF-token */
+export interface LoginResponse {
+    /** CSRF-token (returneres ved in-memory CSRF-modus) */
+    csrfToken?: string;
+}
+/**
+ * Respons fra getSession — returnerer 2xx for både autentiserte og anonyme
+ * brukere, slik at nettleseren ikke logger 401 i konsollen ved sessjonssjekk.
+ */
+export interface SessionResponse<TUser = unknown> {
+    /** Om bruker er autentisert */
+    authenticated: boolean;
+    /** Brukerdata (kun satt når authenticated=true) */
+    user?: TUser;
+}
+/** Auth-API returnert av createAuthApi() */
+export interface AuthApi {
+    /** Send engangskode til e-post */
+    requestCode: (email: string) => Promise<void>;
+    /** Verifiser engangskode */
+    verifyCode: (email: string, code: string) => Promise<LoginResponse>;
+    /** Hent innlogget bruker */
+    getMe: <TUser>() => Promise<TUser>;
+    /** Hent sesjonsstatus (2xx både for anonyme og autentiserte) */
+    getSession: <TUser>() => Promise<SessionResponse<TUser>>;
+    /** Logg ut */
+    logout: () => Promise<void>;
+}
+/** Konfigurasjon for auth-API-endepunkter */
+export interface AuthApiConfig {
+    /** Endepunkt for å sende engangskode (default: '/auth/request-code') */
+    requestCodeEndpoint?: string;
+    /** Endepunkt for å verifisere kode (default: '/auth/verify-code') */
+    verifyCodeEndpoint?: string;
+    /** Endepunkt for å hente brukerinfo (default: '/auth/me') */
+    meEndpoint?: string;
+    /** Endepunkt for utlogging (default: '/auth/logout') */
+    logoutEndpoint?: string;
+    /** Endepunkt for sesjonssjekk (default: '/auth/session') */
+    sessionEndpoint?: string;
+}
+/**
+ * Opprett auth-API-funksjoner som bruker en apiClient-instans.
+ *
+ * @param apiClient - API-klient fra createApiClient()
+ * @param config - Valgfri konfigurasjon av endepunkter
+ * @returns AuthApi med requestCode, verifyCode, getMe, getSession, logout
+ */
+export declare function createAuthApi(apiClient: ApiClient, config?: AuthApiConfig): AuthApi;

--- a/dist/auth/authApi.js
+++ b/dist/auth/authApi.js
@@ -1,0 +1,52 @@
+/**
+ * Generisk auth-API som bruker apiClient for kommunikasjon.
+ *
+ * Tilbyr requestCode, verifyCode, getMe og logout — felles for alle apper.
+ *
+ * @example
+ * ```ts
+ * const authApi = createAuthApi(apiClient)
+ * await authApi.requestCode('ola@example.com')
+ * const result = await authApi.verifyCode('ola@example.com', '123456')
+ * const user = await authApi.getMe<MyUser>()
+ * await authApi.logout()
+ * ```
+ */
+/**
+ * Opprett auth-API-funksjoner som bruker en apiClient-instans.
+ *
+ * @param apiClient - API-klient fra createApiClient()
+ * @param config - Valgfri konfigurasjon av endepunkter
+ * @returns AuthApi med requestCode, verifyCode, getMe, getSession, logout
+ */
+export function createAuthApi(apiClient, config) {
+    const requestCodeEndpoint = config?.requestCodeEndpoint ?? '/auth/request-code';
+    const verifyCodeEndpoint = config?.verifyCodeEndpoint ?? '/auth/verify-code';
+    const meEndpoint = config?.meEndpoint ?? '/auth/me';
+    const logoutEndpoint = config?.logoutEndpoint ?? '/auth/logout';
+    const sessionEndpoint = config?.sessionEndpoint ?? '/auth/session';
+    async function requestCode(email) {
+        await apiClient.request(requestCodeEndpoint, {
+            method: 'POST',
+            body: { email },
+        });
+    }
+    async function verifyCode(email, code) {
+        return apiClient.request(verifyCodeEndpoint, {
+            method: 'POST',
+            body: { email, code },
+        });
+    }
+    async function getMe() {
+        return apiClient.request(meEndpoint);
+    }
+    async function getSession() {
+        return apiClient.request(sessionEndpoint);
+    }
+    async function logout() {
+        await apiClient.request(logoutEndpoint, {
+            method: 'POST',
+        });
+    }
+    return { requestCode, verifyCode, getMe, getSession, logout };
+}

--- a/dist/components/ErrorBoundary.d.ts
+++ b/dist/components/ErrorBoundary.d.ts
@@ -1,0 +1,59 @@
+/**
+ * Styling-agnostisk ErrorBoundary-komponent.
+ *
+ * Fanger ubehandlede feil i React-komponenttreet og viser en
+ * konfigurerbar fallback-UI. Støtter både enkel ReactNode-fallback
+ * og render-funksjon med error + reset-callback.
+ *
+ * @example
+ * ```tsx
+ * // Enkel bruk med standard fallback
+ * <ErrorBoundary>
+ *   <App />
+ * </ErrorBoundary>
+ *
+ * // Med custom render-funksjon
+ * <ErrorBoundary
+ *   fallback={(error, reset) => (
+ *     <div>
+ *       <p>Feil: {error.message}</p>
+ *       <button onClick={reset}>Prøv igjen</button>
+ *     </div>
+ *   )}
+ *   onError={(error, info) => loggTilServer(error)}
+ * >
+ *   <App />
+ * </ErrorBoundary>
+ * ```
+ */
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+/** Props for ErrorBoundary-komponenten */
+export interface ErrorBoundaryProps {
+    /** Barn som beskyttes av error boundary */
+    children: ReactNode;
+    /** CSS-klasse på wrapper-elementet ved feil */
+    className?: string;
+    /** Fallback-UI: ReactNode eller render-funksjon med (error, reset) */
+    fallback?: ReactNode | ((error: Error, reset: () => void) => ReactNode);
+    /** Callback når feil fanges — for logging/rapportering */
+    onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+interface ErrorBoundaryState {
+    error: Error | null;
+}
+/**
+ * Error Boundary som fanger ubehandlede feil i komponenttreet.
+ *
+ * Class component er påkrevd — React har ingen hook-ekvivalent
+ * for getDerivedStateFromError/componentDidCatch.
+ */
+export declare class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    constructor(props: ErrorBoundaryProps);
+    static getDerivedStateFromError(error: Error): ErrorBoundaryState;
+    componentDidCatch(error: Error, errorInfo: ErrorInfo): void;
+    /** Nullstill feilstatus — lar brukeren prøve å rendre på nytt */
+    private reset;
+    render(): string | number | bigint | boolean | Iterable<ReactNode> | Promise<string | number | bigint | boolean | import("react").ReactPortal | import("react").ReactElement<unknown, string | import("react").JSXElementConstructor<any>> | Iterable<ReactNode> | null | undefined> | import("react/jsx-runtime").JSX.Element | null | undefined;
+}
+export {};

--- a/dist/components/ErrorBoundary.js
+++ b/dist/components/ErrorBoundary.js
@@ -1,0 +1,73 @@
+import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
+/**
+ * Styling-agnostisk ErrorBoundary-komponent.
+ *
+ * Fanger ubehandlede feil i React-komponenttreet og viser en
+ * konfigurerbar fallback-UI. Støtter både enkel ReactNode-fallback
+ * og render-funksjon med error + reset-callback.
+ *
+ * @example
+ * ```tsx
+ * // Enkel bruk med standard fallback
+ * <ErrorBoundary>
+ *   <App />
+ * </ErrorBoundary>
+ *
+ * // Med custom render-funksjon
+ * <ErrorBoundary
+ *   fallback={(error, reset) => (
+ *     <div>
+ *       <p>Feil: {error.message}</p>
+ *       <button onClick={reset}>Prøv igjen</button>
+ *     </div>
+ *   )}
+ *   onError={(error, info) => loggTilServer(error)}
+ * >
+ *   <App />
+ * </ErrorBoundary>
+ * ```
+ */
+import { Component } from 'react';
+/**
+ * Error Boundary som fanger ubehandlede feil i komponenttreet.
+ *
+ * Class component er påkrevd — React har ingen hook-ekvivalent
+ * for getDerivedStateFromError/componentDidCatch.
+ */
+export class ErrorBoundary extends Component {
+    constructor(props) {
+        super(props);
+        /** Nullstill feilstatus — lar brukeren prøve å rendre på nytt */
+        this.reset = () => {
+            this.setState({ error: null });
+        };
+        this.state = { error: null };
+    }
+    static getDerivedStateFromError(error) {
+        return { error };
+    }
+    componentDidCatch(error, errorInfo) {
+        this.props.onError?.(error, errorInfo);
+    }
+    render() {
+        const { error } = this.state;
+        const { children, className, fallback } = this.props;
+        if (error) {
+            let content;
+            if (typeof fallback === 'function') {
+                content = fallback(error, this.reset);
+            }
+            else if (fallback !== undefined) {
+                content = fallback;
+            }
+            else {
+                content = (_jsxs(_Fragment, { children: [_jsx("p", { children: "Noe gikk galt" }), _jsx("button", { type: "button", onClick: this.reset, children: "Last inn p\u00E5 nytt" })] }));
+            }
+            if (className) {
+                return _jsx("div", { className: className, children: content });
+            }
+            return _jsx(_Fragment, { children: content });
+        }
+        return children;
+    }
+}

--- a/dist/components/ProtectedRoute.d.ts
+++ b/dist/components/ProtectedRoute.d.ts
@@ -1,0 +1,42 @@
+/**
+ * Konfigurerbar ProtectedRoute-komponent for rutebeskyttelse.
+ *
+ * Factory-funksjon som tar en useAuth-hook og returnerer en
+ * ProtectedRoute-komponent bundet til den spesifikke auth-konteksten.
+ *
+ * @example
+ * ```tsx
+ * const { AuthProvider, useAuth } = createAuthProvider<MyUser>({...})
+ * const ProtectedRoute = createProtectedRoute(useAuth)
+ *
+ * // Som layout-route med Outlet:
+ * <Route element={<ProtectedRoute />}>
+ *   <Route path="/dashboard" element={<Dashboard />} />
+ * </Route>
+ *
+ * // Med rollesjekk:
+ * <Route element={<ProtectedRoute roleCheck={(u) => u.role === 'admin'} />}>
+ *   <Route path="/admin" element={<Admin />} />
+ * </Route>
+ * ```
+ */
+import type { ReactNode } from 'react';
+import type { AuthContextValue } from '../auth/AuthContext';
+/** Props for ProtectedRoute-komponenten */
+export interface ProtectedRouteProps<TUser> {
+    /** Sti til innloggingsside (default: '/logg-inn') */
+    loginPath?: string;
+    /** Valgfri rollesjekk — returnerer true hvis bruker har tilgang */
+    roleCheck?: (user: TUser) => boolean;
+    /** Redirect-sti ved feilet rollesjekk (default: loginPath) */
+    unauthorizedPath?: string;
+    /** Komponent som vises under lasting */
+    loadingComponent?: ReactNode;
+}
+/**
+ * Opprett en ProtectedRoute-komponent bundet til en spesifikk useAuth-hook.
+ *
+ * @param useAuth - useAuth-hook fra createAuthProvider()
+ * @returns ProtectedRoute React-komponent
+ */
+export declare function createProtectedRoute<TUser>(useAuth: () => AuthContextValue<TUser>): React.FC<ProtectedRouteProps<TUser>>;

--- a/dist/components/ProtectedRoute.js
+++ b/dist/components/ProtectedRoute.js
@@ -1,0 +1,24 @@
+import { Fragment as _Fragment, jsx as _jsx } from "react/jsx-runtime";
+import { Navigate, Outlet } from 'react-router-dom';
+/**
+ * Opprett en ProtectedRoute-komponent bundet til en spesifikk useAuth-hook.
+ *
+ * @param useAuth - useAuth-hook fra createAuthProvider()
+ * @returns ProtectedRoute React-komponent
+ */
+export function createProtectedRoute(useAuth) {
+    function ProtectedRoute({ loginPath = '/logg-inn', roleCheck, unauthorizedPath, loadingComponent, }) {
+        const { isAuthenticated, isLoading, user } = useAuth();
+        if (isLoading) {
+            return _jsx(_Fragment, { children: loadingComponent ?? null });
+        }
+        if (!isAuthenticated) {
+            return _jsx(Navigate, { to: loginPath, replace: true });
+        }
+        if (roleCheck && (!user || !roleCheck(user))) {
+            return _jsx(Navigate, { to: unauthorizedPath ?? loginPath, replace: true });
+        }
+        return _jsx(Outlet, {});
+    }
+    return ProtectedRoute;
+}

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,25 @@
+/**
+ * @tommyskogstad/frontend-core
+ * Felles frontend-bibliotek for Kotlin/Ktor-apper.
+ *
+ * @see README.md for API-referanse og konfigurasjon
+ */
+export declare const VERSION: string;
+export { createApiClient, ApiError } from './api/apiClient';
+export type { ApiClientConfig, RequestOptions, ApiClient } from './api/apiClient';
+export { createAuthProvider } from './auth/AuthContext';
+export type { AuthContextValue, AuthProviderConfig } from './auth/AuthContext';
+export { createAuthApi } from './auth/authApi';
+export type { AuthApi, AuthApiConfig, LoginResponse } from './auth/authApi';
+export { ErrorBoundary } from './components/ErrorBoundary';
+export type { ErrorBoundaryProps } from './components/ErrorBoundary';
+export { createProtectedRoute } from './components/ProtectedRoute';
+export type { ProtectedRouteProps } from './components/ProtectedRoute';
+export { createQueryClient } from './query/queryClient';
+export { formatCurrency, formatDate, formatDateTime, formatNumber, formatFileSize, relativeTime } from './lib/formatters';
+export { AnalyticsProvider } from './analytics/AnalyticsProvider';
+export type { AnalyticsProviderProps } from './analytics/AnalyticsProvider';
+export { useAnalytics } from './analytics/useAnalytics';
+export { TrackClick } from './analytics/TrackClick';
+export type { TrackClickProps } from './analytics/TrackClick';
+export { usePageView } from './analytics/usePageView';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,25 @@
+/**
+ * @tommyskogstad/frontend-core
+ * Felles frontend-bibliotek for Kotlin/Ktor-apper.
+ *
+ * @see README.md for API-referanse og konfigurasjon
+ */
+import pkg from '../package.json';
+export const VERSION = pkg.version;
+// API-klient
+export { createApiClient, ApiError } from './api/apiClient';
+// Auth
+export { createAuthProvider } from './auth/AuthContext';
+export { createAuthApi } from './auth/authApi';
+// Komponenter
+export { ErrorBoundary } from './components/ErrorBoundary';
+export { createProtectedRoute } from './components/ProtectedRoute';
+// Query
+export { createQueryClient } from './query/queryClient';
+// Formatters
+export { formatCurrency, formatDate, formatDateTime, formatNumber, formatFileSize, relativeTime } from './lib/formatters';
+// Analytics
+export { AnalyticsProvider } from './analytics/AnalyticsProvider';
+export { useAnalytics } from './analytics/useAnalytics';
+export { TrackClick } from './analytics/TrackClick';
+export { usePageView } from './analytics/usePageView';

--- a/dist/lib/formatters.d.ts
+++ b/dist/lib/formatters.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Norske formatters for dato, valuta, tall, filstørrelse og relativ tid.
+ * Bruker nb-NO locale via Intl API-er.
+ *
+ * FORUTSETNING: Dette modulet er designet for et single-locale browser-miljø
+ * (nb-NO). Formatter-instansene caches modul-globalt for ytelse og deles
+ * på tvers av alle kall i samme modulinstans. Ikke egnet for SSR med
+ * per-request locale uten refaktor til factory-funksjoner.
+ *
+ * Testing: Hvis du trenger fersk formatter-state (f.eks. ved vi.stubGlobal('Intl'...)),
+ * bruk vi.resetModules() + dynamisk import for å isolere modulen per test.
+ */
+/** Maks antall entries i numberFmtCache — FIFO-purge ved overskridelse */
+export declare const NUMBER_FMT_CACHE_MAX = 10;
+/** Formaterer beløp i NOK: "kr 1 234,50" */
+export declare function formatCurrency(amount: number): string;
+/** Formaterer dato: "08.04.2026" */
+export declare function formatDate(date: string | Date): string;
+/** Formaterer dato med klokkeslett: "08.04.2026, 14:30" */
+export declare function formatDateTime(date: string | Date): string;
+/** Eksponerer cache-størrelse for testing — ikke bruk i produksjonskode */
+export declare function _numberFmtCacheSize(): number;
+/** Formaterer tall med norsk tusenskilletegn og valgfritt antall desimaler */
+export declare function formatNumber(num: number, decimals?: number): string;
+/** Formaterer filstørrelse: "1,5 KB", "2,3 MB" */
+export declare function formatFileSize(bytes: number): string;
+/** Relativ tid: "2 timer siden", "om 3 dager", "i morgen" */
+export declare function relativeTime(date: string | Date): string;

--- a/dist/lib/formatters.js
+++ b/dist/lib/formatters.js
@@ -1,0 +1,113 @@
+/**
+ * Norske formatters for dato, valuta, tall, filstørrelse og relativ tid.
+ * Bruker nb-NO locale via Intl API-er.
+ *
+ * FORUTSETNING: Dette modulet er designet for et single-locale browser-miljø
+ * (nb-NO). Formatter-instansene caches modul-globalt for ytelse og deles
+ * på tvers av alle kall i samme modulinstans. Ikke egnet for SSR med
+ * per-request locale uten refaktor til factory-funksjoner.
+ *
+ * Testing: Hvis du trenger fersk formatter-state (f.eks. ved vi.stubGlobal('Intl'...)),
+ * bruk vi.resetModules() + dynamisk import for å isolere modulen per test.
+ */
+const LOCALE = 'nb-NO';
+const DASH = '–'; // tankestrek (–)
+// Lazy-initialiserte Intl-formatters for ytelse
+let currencyFmt;
+let dateFmt;
+let dateTimeFmt;
+let relativeFmt;
+/** Maks antall entries i numberFmtCache — FIFO-purge ved overskridelse */
+export const NUMBER_FMT_CACHE_MAX = 10;
+/** Konverterer string | Date til Date, eller null ved ugyldig input */
+function toDate(input) {
+    if (input == null)
+        return null;
+    const d = input instanceof Date ? input : new Date(input);
+    return isNaN(d.getTime()) ? null : d;
+}
+/** Formaterer beløp i NOK: "kr 1 234,50" */
+export function formatCurrency(amount) {
+    if (!isFinite(amount))
+        return DASH;
+    currencyFmt ?? (currencyFmt = new Intl.NumberFormat(LOCALE, { style: 'currency', currency: 'NOK' }));
+    return currencyFmt.format(amount);
+}
+/** Formaterer dato: "08.04.2026" */
+export function formatDate(date) {
+    const d = toDate(date);
+    if (!d)
+        return DASH;
+    dateFmt ?? (dateFmt = new Intl.DateTimeFormat(LOCALE, { day: '2-digit', month: '2-digit', year: 'numeric' }));
+    return dateFmt.format(d);
+}
+/** Formaterer dato med klokkeslett: "08.04.2026, 14:30" */
+export function formatDateTime(date) {
+    const d = toDate(date);
+    if (!d)
+        return DASH;
+    dateTimeFmt ?? (dateTimeFmt = new Intl.DateTimeFormat(LOCALE, {
+        day: '2-digit', month: '2-digit', year: 'numeric',
+        hour: '2-digit', minute: '2-digit'
+    }));
+    return dateTimeFmt.format(d);
+}
+// Cache for formatNumber med ulike desimalverdier
+const numberFmtCache = new Map();
+/** Eksponerer cache-størrelse for testing — ikke bruk i produksjonskode */
+export function _numberFmtCacheSize() {
+    return numberFmtCache.size;
+}
+/** Formaterer tall med norsk tusenskilletegn og valgfritt antall desimaler */
+export function formatNumber(num, decimals) {
+    if (!isFinite(num))
+        return DASH;
+    let fmt = numberFmtCache.get(decimals);
+    if (!fmt) {
+        fmt = new Intl.NumberFormat(LOCALE, {
+            minimumFractionDigits: decimals,
+            maximumFractionDigits: decimals
+        });
+        // FIFO-purge: Map bevarer insertion-order, så .keys().next() gir eldste nøkkel.
+        // undefined er en gyldig nøkkel (decimals er optional) — delete(undefined) er trygt.
+        if (numberFmtCache.size >= NUMBER_FMT_CACHE_MAX) {
+            numberFmtCache.delete(numberFmtCache.keys().next().value);
+        }
+        numberFmtCache.set(decimals, fmt);
+    }
+    return fmt.format(num);
+}
+/** Formaterer filstørrelse: "1,5 KB", "2,3 MB" */
+export function formatFileSize(bytes) {
+    if (!isFinite(bytes) || bytes < 0)
+        return DASH;
+    if (bytes === 0)
+        return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const value = bytes / Math.pow(1024, i);
+    return `${formatNumber(value, i === 0 ? 0 : 1)} ${units[i]}`;
+}
+/** Relativ tid: "2 timer siden", "om 3 dager", "i morgen" */
+export function relativeTime(date) {
+    const d = toDate(date);
+    if (!d)
+        return DASH;
+    relativeFmt ?? (relativeFmt = new Intl.RelativeTimeFormat(LOCALE, { numeric: 'auto' }));
+    const diffMs = d.getTime() - Date.now();
+    const absSec = Math.abs(diffMs / 1000);
+    const thresholds = [
+        [60, 'second', 1],
+        [3600, 'minute', 60],
+        [86400, 'hour', 3600],
+        [2592000, 'day', 86400],
+        [31536000, 'month', 2592000],
+        [Infinity, 'year', 31536000]
+    ];
+    for (const [limit, unit, divisor] of thresholds) {
+        if (absSec < limit) {
+            return relativeFmt.format(Math.round(diffMs / 1000 / divisor), unit);
+        }
+    }
+    return DASH;
+}

--- a/dist/query/queryClient.d.ts
+++ b/dist/query/queryClient.d.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from '@tanstack/react-query';
+import type { DefaultOptions } from '@tanstack/react-query';
+/**
+ * Oppretter en QueryClient med fornuftige defaults for grunnmur-apper.
+ *
+ * Defaults:
+ * - `staleTime`: 300 000 ms (5 min) — reduserer unødvendige refetches
+ * - `retry`: 1 — én retry, unngår aggressive retry-loops
+ * - `gcTime`: 300 000 ms (5 min) — standard cache-levetid
+ *
+ * @param overrides - Valgfri konfigurasjon som merges med defaults
+ */
+export declare function createQueryClient(overrides?: DefaultOptions): QueryClient;

--- a/dist/query/queryClient.js
+++ b/dist/query/queryClient.js
@@ -1,0 +1,24 @@
+import { QueryClient } from '@tanstack/react-query';
+/**
+ * Oppretter en QueryClient med fornuftige defaults for grunnmur-apper.
+ *
+ * Defaults:
+ * - `staleTime`: 300 000 ms (5 min) — reduserer unødvendige refetches
+ * - `retry`: 1 — én retry, unngår aggressive retry-loops
+ * - `gcTime`: 300 000 ms (5 min) — standard cache-levetid
+ *
+ * @param overrides - Valgfri konfigurasjon som merges med defaults
+ */
+export function createQueryClient(overrides) {
+    return new QueryClient({
+        defaultOptions: {
+            queries: {
+                staleTime: 300000,
+                retry: 1,
+                gcTime: 300000,
+                ...overrides?.queries,
+            },
+            mutations: overrides?.mutations,
+        },
+    });
+}


### PR DESCRIPTION
Fixes #133

## Hva ble gjort

Fjernet `dist/` fra `.gitignore` og committet kompilerte filer til git.

**Rotårsak**: `dist/` var gitignored. Konsumentapper (biologportal, 6810, styreportal, smart-casual) bruker grunnmur-frontend via BuildKit `additional_contexts` fra lokalt filsystem. App-deploys kjørte `git pull --ff-only` men ikke `npm run build` — ny `src/` kom ned, men `dist/*.d.ts` ble aldri oppdatert. Resulterte i TS2322-feil på 3 prod-deploys 28. mai 06:38–07:06.

**Løsning**: Git er nå kilde til sannhet for `dist/`. Konsumentapper får alltid fersk dist via `git pull --ff-only` uten workflow-endringer.

**Fremover**: Alle PR-er som endrer `src/` MÅ inkludere et oppdatert `npm run build`-resultat i `dist/`. CI vil ikke håndheve dette automatisk enda — se issue for mulig oppfølging (GitHub Actions sjekk eller overgang til npm-pakke publisering som langsiktig løsning).

## Endringer

- `.gitignore`: fjernet `dist/`-linje
- `.gitattributes`: `dist/** linguist-generated=true` (kollapser dist/-diff i GitHub PR-visning)
- `dist/**`: 29 kompilerte JS- og TypeScript-deklarasjonsfiler committet

## Test

Ingen unit-test — dette er en build-config/prosess-endring. Verifisering: konsumentapper kompilerer uten TS-feil etter merge.