### PR TITLE
Fix #135: pin react-router-dom peer-range to ^7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "react-router-dom": "^6.0.0 || ^7.0.0",
+    "react-router-dom": "^7.0.0",
     "@tanstack/react-query": "^5.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Fixes #135

## Changes
- Pin  peer-range from  to 
- All consumer apps (biologportal, 6810, styreportal) are now on v7.15.1

## Why
- Eliminates multi-major peer-range that promises compatibility without verification
- Prevents version drift between packages
- npm install will now fail (ERESOLVE) if a consumer app tries to use v6

## Tests
- All existing tests pass (174 tests)
- Manual verification: npm install in a consumer app with v6 in package.json will now fail with ERESOLVE error