### PR TITLE
ci: pin GitHub Actions til SHA — grunnmur-frontend

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.GRUNNMUR_APP_ID }}
           private-key: ${{ secrets.GRUNNMUR_APP_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
   test:
     runs-on: [self-hosted, linux, nuc]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 


### PR DESCRIPTION
Pinner alle `uses:`-referanser til full commit SHA med `pinact v4`.

Funksjonelt identisk (samme tag, bare eksplisitt SHA).

Fixes #138

Del av TommySkogstad/misc-scripts#846.