### PR TITLE
Fix #148: remove summa-summarum from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,6 @@ npm run lint      # ESLint
 
 | App | Spesielle hensyn |
 |-----|------------------|
-| summa-summarum | Pilot. Enklest app |
 | 6810 | In-memory CSRF |
 | styreportal | Multi-tenant (TenantContext) |
 | biologportal | React Query, TOTP, Observer-rolle |


### PR DESCRIPTION
Fixes #148

summa-summarum does not exist as a project in the portfolio and is not 
referenced elsewhere. Removed the obsolete entry from the consumer apps table.