### PR TITLE
docs: clarify TypeScript version in CHANGELOG [1.0.0] (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ Forste stabile release av `@tommyskogstad/frontend-core`.
 
 ### Teknisk
 
-- TypeScript 5.7+ med strict mode
+- TypeScript 5.7+ med strict mode _(bumped til 6.0.3 i [1.0.1])_
 - React 18/19 stotte
 - react-router-dom 6/7 stotte
 - Vitest + Testing Library for tester


### PR DESCRIPTION
Fixes #146

Legger til kryssreferanse til [1.0.1] på TypeScript 5.7+-linjen i [1.0.0]-seksjonen av CHANGELOG, slik at lesere som scanner historikken ser at 6.0.3 er nåværende versjon uten å måtte scrolle videre.