### PR TITLE
docs: update react-router-dom peer dep to ^7.0 only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,13 +100,11 @@ React-instanser i bundlet (en fra grunnmurs node_modules, en fra konsumentens
 egen) — og alle hooks fra grunnmur (AuthProvider, ErrorBoundary etc.) krasjer
 med `Cannot read properties of null (reading 'useState')` på initial render.
 
-Samme bug rammer `react-router-dom`: grunnmur har v7 i devDependencies, mens
-konsumentene bruker v6. Når grunnmurs `node_modules/react-router-dom@7.x`
-kopieres inn, bundler Vite to instanser. Grunnmurs `ProtectedRoute` bruker
-`Outlet`/`Navigate` fra v7, mens konsumentens `<BrowserRouter>` bruker v6 sitt
-Router-context — resultatet er at `<Outlet>` rendrer ingenting (silent) og
-`<Navigate>` kaster «may be used only in the context of a \<Router\> component».
-Se issue #26 og biologportal-incidenten 2026-04-10.
+**Versjonskrav:** Grunnmur KREVER `react-router-dom` ^7.0 og støtter ikke v6.
+Konsumentapper må derfor også bruke v7. Historisk ble v6-kompatibilitet droppet
+i #135 fordi grunnmurs `ProtectedRoute` bruker v7-spesifikke features (`Outlet`/`Navigate`).
+Se issue #26 for bakgrunnen på den tidligere v6/v7-dobbel-instansmeldingen
+(biologportal-incident 2026-04-10, nå løst).
 
 React-incidenten (runde 1) traff biologportal og lo-finans 2026-04-10 — fire
 påfølgende deploys i biologportal feilet smoke-test [7/7] før rotårsaken ble

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Pakken krever disse som peer dependencies:
 |-------|---------|-------------|
 | `react` | ^18.0 \|\| ^19.0 | Ja |
 | `react-dom` | ^18.0 \|\| ^19.0 | Ja |
-| `react-router-dom` | ^6.0 \|\| ^7.0 | Ja |
+| `react-router-dom` | ^7.0 | Ja |
 | `@tanstack/react-query` | ^5.0 | Valgfritt |
 
 ## Quick start


### PR DESCRIPTION
Fixes #144

After #135 dropped v6 support, package.json requires react-router-dom ^7.0.0 only.

**Changes:**
- README: Update peer deps table (line 34) from `^6.0 || ^7.0` to `^7.0`
- CLAUDE.md: Clarify that v6 is no longer supported, consumers must use v7