### PR TITLE
Fix #154: resetUnauthorizedFlag() ved mislykket innlogging

### DIFF
--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -720,6 +720,40 @@ describe('createAuthProvider', () => {
     expect(screen.getByTestId('auth').textContent).toBe('false')
   })
 
+  it('login: resetUnauthorizedFlag kalles selv når verifyCode kaster', async () => {
+    vi.mocked(mockClient.request).mockImplementation(async (path: string) => {
+      if (path === '/auth/me') throw new ApiError('Unauthorized', 401, 'Unauthorized')
+      if (path === '/auth/verify-code') throw new ApiError('Ugyldig kode', 401, 'Unauthorized')
+      return undefined
+    })
+
+    const { AuthProvider, useAuth } = createAuthProvider<TestUser>({
+      apiClient: mockClient,
+    })
+
+    let loginFn: ((email: string, code: string) => Promise<unknown>) | null = null
+
+    function TestComponent() {
+      const { login } = useAuth()
+      loginFn = login
+      return <div />
+    }
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(loginFn).not.toBeNull())
+
+    await expect(act(async () => {
+      await loginFn!('ola@example.com', 'feil-kode')
+    })).rejects.toThrow()
+
+    expect(mockClient.resetUnauthorizedFlag).toHaveBeenCalled()
+  })
+
   it('unmount under pågående fetchUser produserer ikke feil etter resolve', async () => {
     let resolveMe: ((value: TestUser) => void) | undefined
 

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -136,10 +136,9 @@ export function createAuthProvider<TUser>(config: AuthProviderConfig<TUser>): {
     }, [fetchUser])
 
     const login = useCallback(async (email: string, code: string): Promise<LoginResponse> => {
-      const response = await authApi.verifyCode(email, code)
-      // Etter vellykket login, hent brukerinfo
-      await fetchUser()
       apiClient.resetUnauthorizedFlag()
+      const response = await authApi.verifyCode(email, code)
+      await fetchUser()
       return response
     }, [fetchUser])
 


### PR DESCRIPTION
Fixes #154

Flytter `apiClient.resetUnauthorizedFlag()` til starten av `login()` så dedupliseringsflagget nullstilles uansett om `verifyCode()` kaster eller lykkes.

**Scenario som nå er fikset:**
1. Token utløper → 401 → `unauthorizedHandled = true` → redirect til innlogging
2. Bruker taster feil kode → `verifyCode()` kaster
3. Neste 401 fra bakgrunnsanrop håndteres nå korrekt (flagget er nullstilt)