### PR TITLE
docs: tag [1.1.0], legg til _numberFmtCacheSize-fjerning, oppdater CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,20 @@ og prosjektet folger [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-10
+
+### Lagt til
+- `AnalyticsProvider`: ny valgfri prop `isDev?: boolean` (default `false`) erstatter intern `import.meta.env.DEV`-sjekk og den globale `ImportMeta`-augmenteringen. Konsumentapper bør sende `isDev={import.meta.env.DEV}` for å beholde gjeldende opptreden. Fixes #129.
+
+### Forbedret
+- `AnalyticsProvider`: `isOptedOut()` cachet via lazy `useState` — unngår gjentatte `localStorage`-kall per render. Fixes #111.
+
 ### Fikset
 - `formDataRequest()` retrijer nå kun POST — PUT/PATCH/DELETE retrijes ikke (ikke idempotente). Fixes #110.
 - brace-expansion bumped til 5.0.6 for å patche GHSA-jxxr-4gwj-5jf2. Fixes #116.
 
-### Forbedret
-- `AnalyticsProvider`: `isOptedOut()` cachet via lazy `useState` — unngår gjentatte `localStorage`-kall per render. Fixes #111.
-- `AnalyticsProvider`: ny valgfri prop `isDev?: boolean` (default `false`) erstatter intern `import.meta.env.DEV`-sjekk og den globale `ImportMeta`-augmenteringen. Konsumentapper bør sende `isDev={import.meta.env.DEV}` for å beholde gjeldende opptreden. Fixes #129.
+### Fjernet
+- `_numberFmtCacheSize` er fjernet fra public API (`lib/formatters`). Symbolet var aldri ment som del av det stabile grensesnittet (underscore-prefiks = intern implementasjonsdetalje), men var ved en feiltakelse eksportert. Closes #156.
 
 ## [1.0.2] - 2026-05-20
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,13 +29,13 @@ npm run lint      # ESLint
 |-------|-------------|--------|
 | `api/apiClient` | Konfigurerbar fetch-wrapper med CSRF | Implementert |
 | `auth/AuthContext` | Generisk AuthProvider med hooks | Implementert |
-| `auth/authApi` | requestCode, verifyCode, getMe, logout | Implementert |
+| `auth/authApi` | requestCode, verifyCode, getMe, getSession, logout | Implementert |
 | `components/ErrorBoundary` | Styling-agnostisk error boundary | Implementert |
 | `components/ProtectedRoute` | Konfigurerbar med roleCheck callback | Implementert |
 | `lib/queryClient` | Standard QueryClient-config | Implementert |
 | `lib/formatters` | Dato, valuta, tall | Implementert |
 | `analytics/AnalyticsProvider` | Umami-provider med opt-out og dev-mode | Implementert |
-| `analytics/useAnalytics` | Hook for manuell event-sporing | Implementert |
+| `analytics/useAnalytics` | Hook for manuell event-sporing — returnerer `{ trackEvent, identify, reset }` | Implementert |
 | `analytics/TrackClick` | Deklarativ wrapper for klikk-sporing | Implementert |
 | `analytics/usePageView` | Hook for SPA-sidevisnings-sporing | Implementert |
 


### PR DESCRIPTION
Fixes #163

## Endringer
- CHANGELOG.md: Legger til manglende `_numberFmtCacheSize`-fjerning under `### Fjernet` i ny `[1.1.0]`-seksjon
- CHANGELOG.md: Flytter alle `[Unreleased]`-oppføringer til versjonert `[1.1.0] - 2026-06-10` (ny `isDev`-prop = minor bump)
- CLAUDE.md: `auth/authApi` — legger til `getSession` i metodeoversikten
- CLAUDE.md: `analytics/useAnalytics` — dokumenterer `{ trackEvent, identify, reset }`-eksporten