### PR TITLE
Fix #165: rebuild dist/ (stale artifacts fra #154 og #156)

### DIFF
--- a/dist/analytics/AnalyticsProvider.d.ts
+++ b/dist/analytics/AnalyticsProvider.d.ts
@@ -33,4 +33,4 @@ export interface AnalyticsProviderProps {
 /**
  * Laster Umami analytics-skriptet og tilgjengeliggjør tracking via kontekst.
  */
-export declare function AnalyticsProvider({ websiteId, scriptSrc, isDev, children }: AnalyticsProviderProps): import("react/jsx-runtime").JSX.Element;
+export declare function AnalyticsProvider({ websiteId, scriptSrc, isDev, children }: AnalyticsProviderProps): import("react").JSX.Element;

--- a/dist/analytics/TrackClick.d.ts
+++ b/dist/analytics/TrackClick.d.ts
@@ -21,4 +21,4 @@ export interface TrackClickProps {
  * Injiserer trackEvent i barnelementets onClick-handler.
  * Er barnelementet ikke et React-element, rendres det uten sporing.
  */
-export declare function TrackClick({ event, data, children }: TrackClickProps): import("react/jsx-runtime").JSX.Element;
+export declare function TrackClick({ event, data, children }: TrackClickProps): import("react").JSX.Element;

--- a/dist/auth/AuthContext.js
+++ b/dist/auth/AuthContext.js
@@ -81,10 +81,9 @@ export function createAuthProvider(config) {
             await fetchUser();
         }, [fetchUser]);
         const login = useCallback(async (email, code) => {
-            const response = await authApi.verifyCode(email, code);
-            // Etter vellykket login, hent brukerinfo
-            await fetchUser();
             apiClient.resetUnauthorizedFlag();
+            const response = await authApi.verifyCode(email, code);
+            await fetchUser();
             return response;
         }, [fetchUser]);
         const logout = useCallback(async () => {

--- a/dist/components/ErrorBoundary.d.ts
+++ b/dist/components/ErrorBoundary.d.ts
@@ -54,6 +54,6 @@ export declare class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
     componentDidCatch(error: Error, errorInfo: ErrorInfo): void;
     /** Nullstill feilstatus — lar brukeren prøve å rendre på nytt */
     private reset;
-    render(): string | number | bigint | boolean | Iterable<ReactNode> | Promise<string | number | bigint | boolean | import("react").ReactPortal | import("react").ReactElement<unknown, string | import("react").JSXElementConstructor<any>> | Iterable<ReactNode> | null | undefined> | import("react/jsx-runtime").JSX.Element | null | undefined;
+    render(): string | number | bigint | boolean | Iterable<ReactNode> | Promise<string | number | bigint | boolean | import("react").ReactPortal | import("react").ReactElement<unknown, string | import("react").JSXElementConstructor<any>> | Iterable<ReactNode> | null | undefined> | import("react").JSX.Element | null | undefined;
 }
 export {};

--- a/dist/lib/formatters.d.ts
+++ b/dist/lib/formatters.d.ts
@@ -18,8 +18,6 @@ export declare function formatCurrency(amount: number): string;
 export declare function formatDate(date: string | Date): string;
 /** Formaterer dato med klokkeslett: "08.04.2026, 14:30" */
 export declare function formatDateTime(date: string | Date): string;
-/** Eksponerer cache-størrelse for testing — ikke bruk i produksjonskode */
-export declare function _numberFmtCacheSize(): number;
 /** Formaterer tall med norsk tusenskilletegn og valgfritt antall desimaler */
 export declare function formatNumber(num: number, decimals?: number): string;
 /** Formaterer filstørrelse: "1,5 KB", "2,3 MB" */

--- a/dist/lib/formatters.js
+++ b/dist/lib/formatters.js
@@ -54,10 +54,6 @@ export function formatDateTime(date) {
 }
 // Cache for formatNumber med ulike desimalverdier
 const numberFmtCache = new Map();
-/** Eksponerer cache-størrelse for testing — ikke bruk i produksjonskode */
-export function _numberFmtCacheSize() {
-    return numberFmtCache.size;
-}
 /** Formaterer tall med norsk tusenskilletegn og valgfritt antall desimaler */
 export function formatNumber(num, decimals) {
     if (!isFinite(num))


### PR DESCRIPTION
Fixes #165

## Hva ble gjort

`dist/` var sist committed i `1b24301` (2026-05-28). To etterfølgende commits endret `src/` uten å gjenoppbygge:

- `21e6dc3` — reset `unauthorizedFlag` FØR `verifyCode`, ikke etter (closes #154)
- `b545b08` — fjernet `_numberFmtCacheSize` fra public API (closes #156)

### Konkrete endringer i dist/
- `dist/auth/AuthContext.js` — rekkefølge korrigert: `resetUnauthorizedFlag()` skjer nå før `verifyCode()`
- `dist/lib/formatters.d.ts` + `formatters.js` — `_numberFmtCacheSize()` fjernet

## Test
176/176 tester grønne etter rebuild.