### PR TITLE
Fix #169: dokumentasjonsfikser — CHANGELOG og README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,6 @@ Forste stabile release av `@tommyskogstad/frontend-core`.
 
 - TypeScript 5.7+ med strict mode _(bumped til 6.0.3 i [1.0.1])_
 - React 18/19 stotte
-- react-router-dom 6/7 stotte
+- react-router-dom ^7.0 (v6-støtte fjernet i #135)
 - Vitest + Testing Library for tester
 - Publisert til GitHub Packages (privat, `@tommyskogstad` scope)

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ export default [
 
 ## Konfigurasjon per app
 
-### summa-summarum (enklest oppsett)
+### Grunnleggende oppsett
 
 ```ts
 const api = createApiClient({


### PR DESCRIPTION
Fixes #169

To dokumentasjonsfeil etter at react-router-dom v6-støtte ble fjernet i #135:

- CHANGELOG [1.0.0]: «react-router-dom 6/7 støtte» → «react-router-dom ^7.0 (v6-støtte fjernet i #135)»
- README.md: seksjon «summa-summarum» (avviklet prosjekt 2026-04-08) omdøpt til «Grunnleggende oppsett»

Del av #166 (Porteføljegjennomgang 2026-06).