### PR TITLE
Fix #179: setCsrfToken dev-guard bruker import.meta.env.DEV (ikke PROD-negasjon)

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -147,7 +147,7 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
 
   function setCsrfToken(token: string): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (csrfSource !== 'memory' && (import.meta as any).env?.PROD !== true) {
+    if (csrfSource !== 'memory' && (import.meta as any).env?.DEV === true) {
       console.warn(
         '[ApiClient] setCsrfToken() kallt i cookie-mode — kallet er en no-op. ' +
         'Bruk csrfSource: "memory" hvis du vil styre token manuelt.'


### PR DESCRIPTION
Lukker review-gate-funnet i #179 (post-merge CRITICAL på PR #178).

## Bakgrunn
Commit e10f903 endret dev-guarden til `import.meta.env?.PROD !== true`. Den defaulter til **warn-on** når `import.meta.env` er `undefined` (`undefined !== true` → `true`). For et `tsc`-bygd bibliotek som kan konsumeres utenfor Vite (SSR/Node/test) kunne dette logge `console.warn` utenfor dev-miljø — brudd på AC i #172 («kun dev-miljø»).

## Fiks
`import.meta.env?.DEV === true` — defaulter til **warn-off**: varsler kun når Vite eksplisitt setter DEV, stille når env mangler. Beholder `as any`-casten så den kompilerer under ren `tsc` uten `@types/node` (review-gatens foreslåtte `process.env`-revert ville krevd det, og er ikke idiomatisk for et browser-bibliotek).

## Verifikasjon
- Alle 120 apiClient-tester grønne (dev-guard-testen passerer fordi Vitest setter `DEV=true`).
- Empirisk: bugen var **aldri i prod** — committed `dist/` er stale fra 28. mai (pre-e10f903), så ingen deployet bundle inneholder warn-strengen. Denne PR-en herder kilden så den aldri shipper når `dist/` rebuildes.

## Merk (separat funn, ikke i denne PR-en)
`dist/` er committed og stale → alle dagens grunnmur-fikser (#171/#172/#173) er ikke i prod. Egen vurdering kreves før dist-rebuild (#171 fjerner public exports → potensielt breaking for konsumenter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)