### PR TITLE
Fix #183: rebuild dist/ to ship src changes since May 28

### DIFF
--- a/dist/analytics/useAnalytics.d.ts
+++ b/dist/analytics/useAnalytics.d.ts
@@ -29,15 +29,6 @@ declare global {
     }
 }
 /**
- * Hash en bruker-ID til et pseudonym (16 hex-tegn) via SHA-256.
- *
- * Salt er per-app (default = window.location.hostname) slik at samme bruker
- * får ulike pseudonymer på tvers av apper — forhindrer cross-app-tracking.
- *
- * @internal
- */
-export declare function hashUserId(userId: string, salt?: string): Promise<string>;
-/**
  * Returnerer trackEvent, identify og reset for analytics.
  *
  * Alle funksjoner er no-op dersom tracking er deaktivert (DEV-modus,

--- a/dist/analytics/useAnalytics.js
+++ b/dist/analytics/useAnalytics.js
@@ -25,7 +25,7 @@ import { useAnalyticsContext } from './analyticsContext';
  *
  * @internal
  */
-export async function hashUserId(userId, salt) {
+async function hashUserId(userId, salt) {
     const effectiveSalt = salt ?? (typeof window !== 'undefined' ? window.location.hostname : '');
     const data = new TextEncoder().encode(`${userId}:${effectiveSalt}`);
     const hash = await crypto.subtle.digest('SHA-256', data);

--- a/dist/api/apiClient.d.ts
+++ b/dist/api/apiClient.d.ts
@@ -49,9 +49,17 @@ export interface ApiClient {
     request: <T>(path: string, options?: RequestOptions) => Promise<T>;
     /** FormData-request for filopplasting */
     formDataRequest: <T>(path: string, formData: FormData, method?: string) => Promise<T>;
+    /** Blob-request for filnedlasting — returnerer Blob med full CSRF/401-håndtering */
+    blobRequest: (path: string, options?: RequestOptions) => Promise<Blob>;
     /** Hent gjeldende CSRF-token */
     getCsrfToken: () => string | null;
-    /** Sett CSRF-token manuelt (for memory-mode) */
+    /**
+     * Sett CSRF-token manuelt.
+     *
+     * **Kun effektiv i `csrfSource: 'memory'`-modus.** I cookie-mode er dette en no-op —
+     * token hentes alltid fra cookie, og kallet har ingen virkning.
+     * Logger `console.warn` i dev-miljø ved kall i cookie-mode.
+     */
     setCsrfToken: (token: string) => void;
     /** Resett 401-deduplisering (kall etter re-autentisering) */
     resetUnauthorizedFlag: () => void;

--- a/dist/api/apiClient.js
+++ b/dist/api/apiClient.js
@@ -77,6 +77,11 @@ export function createApiClient(config) {
         return getCookieValue(csrfCookieName);
     }
     function setCsrfToken(token) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (csrfSource !== 'memory' && import.meta.env?.DEV === true) {
+            console.warn('[ApiClient] setCsrfToken() kallt i cookie-mode — kallet er en no-op. ' +
+                'Bruk csrfSource: "memory" hvis du vil styre token manuelt.');
+        }
         memoryCsrfToken = token;
     }
     function resetUnauthorizedFlag() {
@@ -123,7 +128,7 @@ export function createApiClient(config) {
             throw new ApiError('Ugyldig JSON i respons', response.status, response.statusText);
         }
     }
-    async function fetchWithRetry(fn, maxAttempts) {
+    async function fetchWithRetry(fn, maxAttempts, parser = parseResponse) {
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
             let response;
             try {
@@ -145,7 +150,7 @@ export function createApiClient(config) {
                 }
                 return handleErrorResponse(response);
             }
-            return parseResponse(response);
+            return parser(response);
         }
         // Nådd kun hvis maxAttempts er 0 (aldri i praksis siden minimum er 1)
         throw new ApiError('Nettverksfeil — sjekk tilkoblingen', 0, 'NetworkError');
@@ -187,9 +192,22 @@ export function createApiClient(config) {
             credentials: 'include',
         }), maxFormAttempts);
     }
+    async function blobRequest(path, options) {
+        const method = (options?.method ?? 'GET').toUpperCase();
+        const headers = { ...options?.headers };
+        const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1;
+        if (!SAFE_METHODS.has(method)) {
+            const token = getCsrfToken();
+            if (token) {
+                headers[csrfHeaderName] = token;
+            }
+        }
+        return fetchWithRetry(() => fetch(`${basePath}${path}`, { method, headers, credentials: 'include' }), maxAttempts, (response) => response.blob());
+    }
     return {
         request,
         formDataRequest,
+        blobRequest,
         getCsrfToken,
         setCsrfToken,
         resetUnauthorizedFlag,

--- a/dist/auth/AuthContext.js
+++ b/dist/auth/AuthContext.js
@@ -76,7 +76,7 @@ export function createAuthProvider(config) {
                     onSessionError?.(error);
                 }
             }
-        }, []);
+        }, []); // authApi, parseUser, useSessionEndpoint og onSessionError er factory-scope konstanter, ikke React-tilstand
         const refreshUser = useCallback(async () => {
             await fetchUser();
         }, [fetchUser]);

--- a/dist/lib/formatters.d.ts
+++ b/dist/lib/formatters.d.ts
@@ -10,8 +10,6 @@
  * Testing: Hvis du trenger fersk formatter-state (f.eks. ved vi.stubGlobal('Intl'...)),
  * bruk vi.resetModules() + dynamisk import for å isolere modulen per test.
  */
-/** Maks antall entries i numberFmtCache — FIFO-purge ved overskridelse */
-export declare const NUMBER_FMT_CACHE_MAX = 10;
 /** Formaterer beløp i NOK: "kr 1 234,50" */
 export declare function formatCurrency(amount: number): string;
 /** Formaterer dato: "08.04.2026" */

--- a/dist/lib/formatters.js
+++ b/dist/lib/formatters.js
@@ -18,7 +18,7 @@ let dateFmt;
 let dateTimeFmt;
 let relativeFmt;
 /** Maks antall entries i numberFmtCache — FIFO-purge ved overskridelse */
-export const NUMBER_FMT_CACHE_MAX = 10;
+const NUMBER_FMT_CACHE_MAX = 10;
 /** Konverterer string | Date til Date, eller null ved ugyldig input */
 function toDate(input) {
     if (input == null)


### PR DESCRIPTION
Fixes #183

Rebuilds `dist/` from current `src/` to ship accumulated changes from #171–#182 that were never included in the committed build artifact.

**Consumer safety check:** Verified no consumer (biologportal, 6810, styreportal, smart-casual, maskemester, vinforalle) imports `hashUserId` or `NUMBER_FMT_CACHE_MAX` — the exports removed in #171. No breaking changes.

**Changed files in dist/:**
- `dist/api/apiClient.{js,d.ts}` — retry logic, CSRF guard, and type improvements
- `dist/analytics/useAnalytics.{js,d.ts}` — internal refactor (hashUserId removed from exports)
- `dist/auth/AuthContext.js` — session endpoint config
- `dist/lib/formatters.{js,d.ts}` — NUMBER_FMT_CACHE_MAX removed from exports