### PR TITLE
refactor: extract createMockApiClient to shared test helper (#174)

### DIFF
--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, act, waitFor, cleanup } from '@testing-library/react'
 import { createAuthProvider } from './AuthContext'
 import { ApiError } from '../api/apiClient'
-import type { ApiClient } from '../api/apiClient'
+import { createMockApiClient } from '../test/testHelpers'
 
 interface TestUser {
   id: number
@@ -14,16 +14,6 @@ interface TestUser {
 }
 
 const testUser: TestUser = { id: 1, email: 'ola@example.com', role: 'admin' }
-
-function createMockApiClient(): ApiClient {
-  return {
-    request: vi.fn(),
-    formDataRequest: vi.fn(),
-    getCsrfToken: vi.fn(() => null),
-    setCsrfToken: vi.fn(),
-    resetUnauthorizedFlag: vi.fn(),
-  }
-}
 
 describe('createAuthProvider', () => {
   let mockClient: ApiClient

--- a/src/auth/authApi.test.ts
+++ b/src/auth/authApi.test.ts
@@ -3,17 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createAuthApi } from './authApi'
-import type { ApiClient } from '../api/apiClient'
-
-function createMockApiClient(): ApiClient {
-  return {
-    request: vi.fn(),
-    formDataRequest: vi.fn(),
-    getCsrfToken: vi.fn(() => null),
-    setCsrfToken: vi.fn(),
-    resetUnauthorizedFlag: vi.fn(),
-  }
-}
+import { createMockApiClient } from '../test/testHelpers'
 
 describe('createAuthApi', () => {
   let mockClient: ApiClient

--- a/src/test/testHelpers.ts
+++ b/src/test/testHelpers.ts
@@ -1,0 +1,12 @@
+import { vi } from 'vitest'
+import type { ApiClient } from '../api/apiClient'
+
+export function createMockApiClient(): ApiClient {
+  return {
+    request: vi.fn(),
+    formDataRequest: vi.fn(),
+    getCsrfToken: vi.fn(() => null),
+    setCsrfToken: vi.fn(),
+    resetUnauthorizedFlag: vi.fn(),
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "isolatedModules": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx", "src/test/**"]
 }


### PR DESCRIPTION
Fixes #174

Ekstraherer den identiske `createMockApiClient()`-hjelpefunksjonen fra to testfiler til en delt `src/test/testHelpers.ts`. Begge testfiler importerer nå fra den felles kilden.