### PR TITLE
feat: add ToastProvider and useToast shared context (#176)

### DIFF
--- a/src/context/ToastContext.test.tsx
+++ b/src/context/ToastContext.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, fireEvent, cleanup } from '@testing-library/react'
+import { ToastProvider, useToast } from './ToastContext'
+
+function TestComponent() {
+  const { showToast } = useToast()
+  return (
+    <div>
+      <button onClick={() => showToast('Suksessmelding', 'success')}>Vis success</button>
+      <button onClick={() => showToast('Feilmelding', 'error')}>Vis error</button>
+      <button onClick={() => showToast('Infomelding', 'info')}>Vis info</button>
+    </div>
+  )
+}
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<ToastProvider>{ui}</ToastProvider>)
+}
+
+describe('ToastContext', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('useToast kaster error utenfor ToastProvider', () => {
+    function BadComponent() {
+      useToast()
+      return <div>Should not render</div>
+    }
+
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<BadComponent />)).toThrow('useToast must be used within a ToastProvider')
+    spy.mockRestore()
+  })
+
+  it('showToast viser melding', () => {
+    renderWithProvider(<TestComponent />)
+
+    act(() => {
+      fireEvent.click(screen.getByText('Vis success'))
+    })
+
+    expect(screen.getByText('Suksessmelding')).toBeTruthy()
+  })
+
+  it('toast forsvinner etter timeout (4000ms)', () => {
+    renderWithProvider(<TestComponent />)
+
+    act(() => {
+      fireEvent.click(screen.getByText('Vis success'))
+    })
+
+    expect(screen.getByText('Suksessmelding')).toBeTruthy()
+
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+
+    expect(screen.queryByText('Suksessmelding')).toBeNull()
+  })
+
+  it('toast forsvinner ikke for tidlig', () => {
+    renderWithProvider(<TestComponent />)
+
+    act(() => {
+      fireEvent.click(screen.getByText('Vis success'))
+    })
+
+    expect(screen.getByText('Suksessmelding')).toBeTruthy()
+
+    act(() => {
+      vi.advanceTimersByTime(3999)
+    })
+
+    expect(screen.queryByText('Suksessmelding')).not.toBeNull()
+  })
+
+  it('viser success toast med role="alert"', () => {
+    renderWithProvider(<TestComponent />)
+
+    act(() => {
+      fireEvent.click(screen.getByText('Vis success'))
+    })
+
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(screen.getByText('Suksessmelding')).toBeTruthy()
+  })
+
+  it('viser error toast', () => {
+    renderWithProvider(<TestComponent />)
+
+    act(() => {
+      fireEvent.click(screen.getByText('Vis error'))
+    })
+
+    expect(screen.getByText('Feilmelding')).toBeTruthy()
+    expect(screen.getByRole('alert')).toBeTruthy()
+  })
+
+  it('viser info toast', () => {
+    renderWithProvider(<TestComponent />)
+
+    act(() => {
+      fireEvent.click(screen.getByText('Vis info'))
+    })
+
+    expect(screen.getByText('Infomelding')).toBeTruthy()
+    expect(screen.getByRole('alert')).toBeTruthy()
+  })
+
+  it('aria-live="polite" er satt for skjermlesere', () => {
+    renderWithProvider(<TestComponent />)
+
+    act(() => {
+      fireEvent.click(screen.getByText('Vis success'))
+    })
+
+    const container = screen.getByText('Suksessmelding').closest('[aria-live]')
+    expect(container?.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('kan vise flere toasts samtidig', () => {
+    renderWithProvider(<TestComponent />)
+
+    act(() => {
+      fireEvent.click(screen.getByText('Vis success'))
+      fireEvent.click(screen.getByText('Vis error'))
+    })
+
+    expect(screen.getByText('Suksessmelding')).toBeTruthy()
+    expect(screen.getByText('Feilmelding')).toBeTruthy()
+  })
+
+  it('lukk-knapp fjerner toast manuelt', () => {
+    renderWithProvider(<TestComponent />)
+
+    act(() => {
+      fireEvent.click(screen.getByText('Vis success'))
+    })
+
+    expect(screen.getByText('Suksessmelding')).toBeTruthy()
+
+    act(() => {
+      fireEvent.click(screen.getByLabelText('Lukk'))
+    })
+
+    expect(screen.queryByText('Suksessmelding')).toBeNull()
+  })
+
+  it('toast-container rendres ikke når ingen toasts er aktive', () => {
+    const { container } = renderWithProvider(<TestComponent />)
+    expect(container.querySelector('[aria-live]')).toBeNull()
+  })
+})

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -1,0 +1,119 @@
+import { createContext, useContext, useState, useCallback, useRef } from 'react'
+import type { ReactNode } from 'react'
+
+/** Toast-type for visuell stil og semantikk */
+export type ToastType = 'success' | 'error' | 'info'
+
+interface ToastItem {
+  id: number
+  message: string
+  type: ToastType
+}
+
+/** Verdi eksponert via useToast-hook */
+export interface ToastContextValue {
+  showToast: (message: string, type: ToastType) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+/**
+ * Tilbyr toast-varsler til hele komponenttreet.
+ * Wrap rundt app-roten for å aktivere useToast-hook.
+ */
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([])
+  const idRef = useRef(0)
+
+  const showToast = useCallback((message: string, type: ToastType) => {
+    const id = ++idRef.current
+    setToasts(prev => [...prev, { id, message, type }])
+    setTimeout(() => {
+      setToasts(prev => prev.filter(t => t.id !== id))
+    }, 4000)
+  }, [])
+
+  const removeToast = useCallback((id: number) => {
+    setToasts(prev => prev.filter(t => t.id !== id))
+  }, [])
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <ToastContainer toasts={toasts} onRemove={removeToast} />
+    </ToastContext.Provider>
+  )
+}
+
+/**
+ * Returnerer showToast-funksjonen for å vise toast-varsler.
+ * Må brukes innenfor en ToastProvider.
+ */
+export function useToast() {
+  const context = useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+  return context
+}
+
+function ToastContainer({ toasts, onRemove }: { toasts: ToastItem[]; onRemove: (id: number) => void }) {
+  if (toasts.length === 0) return null
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2" aria-live="polite" aria-atomic="false">
+      {toasts.map(toast => (
+        <ToastItemComponent key={toast.id} toast={toast} onRemove={onRemove} />
+      ))}
+    </div>
+  )
+}
+
+function ToastItemComponent({ toast, onRemove }: { toast: ToastItem; onRemove: (id: number) => void }) {
+  const iconBg = {
+    success: 'bg-success-50',
+    error: 'bg-danger-50',
+    info: 'bg-primary-50',
+  }[toast.type]
+
+  const iconColor = {
+    success: 'text-success-600',
+    error: 'text-danger-600',
+    info: 'text-primary-600',
+  }[toast.type]
+
+  return (
+    <div
+      className="flex items-center gap-3 px-4 py-3 bg-white rounded-xl shadow-lg border border-gray-200 animate-slide-in-right"
+      role="alert"
+    >
+      <div className={`w-8 h-8 rounded-full flex items-center justify-center ${iconBg}`}>
+        {toast.type === 'success' && (
+          <svg className={`h-4 w-4 ${iconColor}`} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        )}
+        {toast.type === 'error' && (
+          <svg className={`h-4 w-4 ${iconColor}`} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+          </svg>
+        )}
+        {toast.type === 'info' && (
+          <svg className={`h-4 w-4 ${iconColor}`} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+          </svg>
+        )}
+      </div>
+      <p className="text-sm font-medium text-gray-900">{toast.message}</p>
+      <button
+        onClick={() => onRemove(toast.id)}
+        className="p-1 text-gray-400 hover:text-gray-600"
+        aria-label="Lukk"
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,10 @@ export {
   relativeTime
 } from './lib/formatters'
 
+// Context
+export { ToastProvider, useToast } from './context/ToastContext'
+export type { ToastType, ToastContextValue } from './context/ToastContext'
+
 // Analytics
 export { AnalyticsProvider } from './analytics/AnalyticsProvider'
 export type { AnalyticsProviderProps } from './analytics/AnalyticsProvider'


### PR DESCRIPTION
Fixes #176

Legger til `ToastProvider`, `useToast` og `ToastType` som delte komponenter i grunnmur-frontend.

## Endringer
- `src/context/ToastContext.tsx` — ToastProvider, useToast, ToastContainer, ToastItem
- `src/context/ToastContext.test.tsx` — 11 tester (rød→grønn)
- `src/index.ts` — eksporterer ToastProvider, useToast, ToastType, ToastContextValue

## Forbedringer fra ARK-analyse
- Bruker `useRef` i stedet for module-level teller (thread-safe i tester)

## Akseptansekriterier
- [x] `src/context/ToastContext.tsx` opprettet
- [x] Eksportert fra `src/index.ts`
- [x] `src/context/ToastContext.test.tsx` med 11 tester (samme dekning som 6810)
- [x] WCAG-tilgjengelig (aria-live, role="alert")