### PR TITLE
Fix #184: ignore self-referencing symlink grunnmur-frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 *.tgz
 .env
 .env.local
+# Prevents self-referencing symlink from being accidentally committed (recreated by consumer builds)
+grunnmur-frontend


### PR DESCRIPTION
Fixes #184

Adds `grunnmur-frontend` to `.gitignore` to prevent the self-referencing symlink that consumer builds recreate from ever being accidentally committed.

The symlink `grunnmur-frontend -> /home/terminator/git/grunnmur-frontend` is likely created by a consumer deploy/build using `additional_contexts: ../../grunnmur-frontend`. This defensive measure ensures it stays untracked and uncommittable.