### PR TITLE
ci: add dist/ freshness guard (closes #186)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,5 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+      - run: git diff --exit-code dist/ || (echo "dist/ er utdatert — kjør 'npm run build' og commit dist/" && exit 1)
       - run: npm test

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -17,6 +17,8 @@ export { createProtectedRoute } from './components/ProtectedRoute';
 export type { ProtectedRouteProps } from './components/ProtectedRoute';
 export { createQueryClient } from './query/queryClient';
 export { formatCurrency, formatDate, formatDateTime, formatNumber, formatFileSize, relativeTime } from './lib/formatters';
+export { ToastProvider, useToast } from './context/ToastContext';
+export type { ToastType, ToastContextValue } from './context/ToastContext';
 export { AnalyticsProvider } from './analytics/AnalyticsProvider';
 export type { AnalyticsProviderProps } from './analytics/AnalyticsProvider';
 export { useAnalytics } from './analytics/useAnalytics';

--- a/dist/index.js
+++ b/dist/index.js
@@ -18,6 +18,8 @@ export { createProtectedRoute } from './components/ProtectedRoute';
 export { createQueryClient } from './query/queryClient';
 // Formatters
 export { formatCurrency, formatDate, formatDateTime, formatNumber, formatFileSize, relativeTime } from './lib/formatters';
+// Context
+export { ToastProvider, useToast } from './context/ToastContext';
 // Analytics
 export { AnalyticsProvider } from './analytics/AnalyticsProvider';
 export { useAnalytics } from './analytics/useAnalytics';


### PR DESCRIPTION
Fixes #186

Adds a freshness-guard step to test.yml: after `npm run build`, checks that `dist/` matches the committed state. CI fails with a clear error message if `dist/` is stale, making it impossible to merge out-of-date builds to main.

No new auto-commit workflow needed — this approach requires no write access and is simpler to maintain.