### PR TITLE
feat!: migrate TrackClick to render prop (closes #195)

### DIFF
--- a/dist/analytics/TrackClick.d.ts
+++ b/dist/analytics/TrackClick.d.ts
@@ -1,24 +1,39 @@
 /**
- * TrackClick — deklarativ wrapper som sporer klikk på barnelementet.
+ * TrackClick — deklarativ render prop som sporer klikk via analytics.
+ *
+ * Gir konsumenten en ferdig onClick-handler som sporer eventet. Konsumenten
+ * plasserer selv handleren og kan kjede sin egen onClick-logikk.
  *
  * @example
  * ```tsx
- * <TrackClick event="cta.opprett-mote">
- *   <Button>Opprett møte</Button>
+ * <TrackClick event="cta.opprett-mote" data={{ side: 'hjem' }}>
+ *   {(onClick) => <Button onClick={onClick}>Opprett møte</Button>}
+ * </TrackClick>
+ *
+ * // Med egen klikk-logikk i tillegg:
+ * <TrackClick event="cta.lagre">
+ *   {(track) => (
+ *     <Button onClick={(e) => { track(e); lagre() }}>Lagre</Button>
+ *   )}
  * </TrackClick>
  * ```
  */
-import type { ReactNode } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 /** Props for TrackClick */
 export interface TrackClickProps {
     /** Navn på eventet som spores ved klikk */
     event: string;
     /** Valgfrie event-data */
     data?: Record<string, unknown>;
-    children: ReactNode;
+    /**
+     * Render prop. Mottar en onClick-handler som sporer eventet.
+     * Konsumenten er ansvarlig for å plassere handleren og eventuelt kjede
+     * sin egen onClick-logikk: `{(track) => <btn onClick={e => { track(e); min() }}>`.
+     */
+    children: (onClick: (e: MouseEvent) => void) => ReactNode;
 }
 /**
- * Injiserer trackEvent i barnelementets onClick-handler.
- * Er barnelementet ikke et React-element, rendres det uten sporing.
+ * Eksponerer en spore-handler til render prop-barnet.
+ * Sporing er no-op i DEV-modus / ved opt-out (styres av useAnalytics).
  */
 export declare function TrackClick({ event, data, children }: TrackClickProps): import("react").JSX.Element;

--- a/dist/analytics/TrackClick.js
+++ b/dist/analytics/TrackClick.js
@@ -1,30 +1,34 @@
 import { Fragment as _Fragment, jsx as _jsx } from "react/jsx-runtime";
 /**
- * TrackClick — deklarativ wrapper som sporer klikk på barnelementet.
+ * TrackClick — deklarativ render prop som sporer klikk via analytics.
+ *
+ * Gir konsumenten en ferdig onClick-handler som sporer eventet. Konsumenten
+ * plasserer selv handleren og kan kjede sin egen onClick-logikk.
  *
  * @example
  * ```tsx
- * <TrackClick event="cta.opprett-mote">
- *   <Button>Opprett møte</Button>
+ * <TrackClick event="cta.opprett-mote" data={{ side: 'hjem' }}>
+ *   {(onClick) => <Button onClick={onClick}>Opprett møte</Button>}
+ * </TrackClick>
+ *
+ * // Med egen klikk-logikk i tillegg:
+ * <TrackClick event="cta.lagre">
+ *   {(track) => (
+ *     <Button onClick={(e) => { track(e); lagre() }}>Lagre</Button>
+ *   )}
  * </TrackClick>
  * ```
  */
-import { cloneElement, isValidElement } from 'react';
+import { useCallback } from 'react';
 import { useAnalytics } from './useAnalytics';
 /**
- * Injiserer trackEvent i barnelementets onClick-handler.
- * Er barnelementet ikke et React-element, rendres det uten sporing.
+ * Eksponerer en spore-handler til render prop-barnet.
+ * Sporing er no-op i DEV-modus / ved opt-out (styres av useAnalytics).
  */
 export function TrackClick({ event, data, children }) {
     const { trackEvent } = useAnalytics();
-    if (!isValidElement(children))
-        return _jsx(_Fragment, { children: children });
-    const child = children;
-    const originalOnClick = child.props.onClick;
-    return cloneElement(child, {
-        onClick: (e) => {
-            trackEvent(event, data);
-            originalOnClick?.(e);
-        },
-    });
+    const handleClick = useCallback((_e) => {
+        trackEvent(event, data);
+    }, [trackEvent, event, data]);
+    return _jsx(_Fragment, { children: children(handleClick) });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tommyskogstad/frontend-core",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Felles frontend-bibliotek for Kotlin/Ktor-apper",
   "type": "module",
   "main": "dist/index.js",

--- a/src/analytics/TrackClick.test.tsx
+++ b/src/analytics/TrackClick.test.tsx
@@ -12,16 +12,14 @@ describe('TrackClick', () => {
     delete (window as Window & { umami?: unknown }).umami
   })
 
-  it('kaller trackEvent og originalOnClick ved klikk', async () => {
+  it('kaller trackEvent ved klikk via render prop', async () => {
     const mockTrack = vi.fn()
     ;(window as Window & { umami?: { track: typeof mockTrack; identify: () => void } }).umami = { track: mockTrack, identify: vi.fn() }
-
-    const originalClick = vi.fn()
 
     const { getByText } = render(
       <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
         <TrackClick event="btn.klikk" data={{ side: 'hjem' }}>
-          <button onClick={originalClick}>Klikk meg</button>
+          {(onClick) => <button onClick={onClick}>Klikk meg</button>}
         </TrackClick>
       </AnalyticsProvider>
     )
@@ -31,36 +29,30 @@ describe('TrackClick', () => {
     })
 
     expect(mockTrack).toHaveBeenCalledWith('btn.klikk', { side: 'hjem' })
-    expect(originalClick).toHaveBeenCalledOnce()
   })
 
-  it('krasjer ikke når barn ikke har onClick', async () => {
+  it('konsumentens onClick kjøres i tillegg til sporing når konsumenten kjeder den', async () => {
     const mockTrack = vi.fn()
     ;(window as Window & { umami?: { track: typeof mockTrack; identify: () => void } }).umami = { track: mockTrack, identify: vi.fn() }
+
+    const egnKlikk = vi.fn()
 
     const { getByText } = render(
       <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
         <TrackClick event="btn.klikk">
-          <button>Ingen onClick</button>
+          {(track) => (
+            <button onClick={(e) => { track(e); egnKlikk(e) }}>Klikk meg</button>
+          )}
         </TrackClick>
       </AnalyticsProvider>
     )
 
     await act(async () => {
-      getByText('Ingen onClick').click()
+      getByText('Klikk meg').click()
     })
 
     expect(mockTrack).toHaveBeenCalledWith('btn.klikk', undefined)
-  })
-
-  it('rendrer ikke-React-element-barn uten sporing', () => {
-    const { getByText } = render(
-      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
-        <TrackClick event="test">ren tekst</TrackClick>
-      </AnalyticsProvider>
-    )
-
-    expect(getByText('ren tekst')).toBeDefined()
+    expect(egnKlikk).toHaveBeenCalledOnce()
   })
 
   it('sporer ikke klikk i DEV-modus', async () => {
@@ -70,7 +62,7 @@ describe('TrackClick', () => {
     const { getByText } = render(
       <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js" isDev={true}>
         <TrackClick event="btn.klikk">
-          <button>Klikk</button>
+          {(onClick) => <button onClick={onClick}>Klikk</button>}
         </TrackClick>
       </AnalyticsProvider>
     )
@@ -80,5 +72,24 @@ describe('TrackClick', () => {
     })
 
     expect(mockTrack).not.toHaveBeenCalled()
+  })
+
+  it('sporer uten data når data er utelatt', async () => {
+    const mockTrack = vi.fn()
+    ;(window as Window & { umami?: { track: typeof mockTrack; identify: () => void } }).umami = { track: mockTrack, identify: vi.fn() }
+
+    const { getByText } = render(
+      <AnalyticsProvider websiteId="test-id" scriptSrc="https://analytics.example.com/script.js">
+        <TrackClick event="btn.ingen-data">
+          {(onClick) => <button onClick={onClick}>Klikk</button>}
+        </TrackClick>
+      </AnalyticsProvider>
+    )
+
+    await act(async () => {
+      getByText('Klikk').click()
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith('btn.ingen-data', undefined)
   })
 })

--- a/src/analytics/TrackClick.tsx
+++ b/src/analytics/TrackClick.tsx
@@ -1,16 +1,26 @@
 /**
- * TrackClick — deklarativ wrapper som sporer klikk på barnelementet.
+ * TrackClick — deklarativ render prop som sporer klikk via analytics.
+ *
+ * Gir konsumenten en ferdig onClick-handler som sporer eventet. Konsumenten
+ * plasserer selv handleren og kan kjede sin egen onClick-logikk.
  *
  * @example
  * ```tsx
- * <TrackClick event="cta.opprett-mote">
- *   <Button>Opprett møte</Button>
+ * <TrackClick event="cta.opprett-mote" data={{ side: 'hjem' }}>
+ *   {(onClick) => <Button onClick={onClick}>Opprett møte</Button>}
+ * </TrackClick>
+ *
+ * // Med egen klikk-logikk i tillegg:
+ * <TrackClick event="cta.lagre">
+ *   {(track) => (
+ *     <Button onClick={(e) => { track(e); lagre() }}>Lagre</Button>
+ *   )}
  * </TrackClick>
  * ```
  */
 
-import { cloneElement, isValidElement } from 'react'
-import type { MouseEvent, ReactElement, ReactNode } from 'react'
+import { useCallback } from 'react'
+import type { MouseEvent, ReactNode } from 'react'
 import { useAnalytics } from './useAnalytics'
 
 /** Props for TrackClick */
@@ -19,27 +29,27 @@ export interface TrackClickProps {
   event: string
   /** Valgfrie event-data */
   data?: Record<string, unknown>
-  children: ReactNode
+  /**
+   * Render prop. Mottar en onClick-handler som sporer eventet.
+   * Konsumenten er ansvarlig for å plassere handleren og eventuelt kjede
+   * sin egen onClick-logikk: `{(track) => <btn onClick={e => { track(e); min() }}>`.
+   */
+  children: (onClick: (e: MouseEvent) => void) => ReactNode
 }
 
-type ClickableElement = ReactElement<{ onClick?: (e: MouseEvent) => void }>
-
 /**
- * Injiserer trackEvent i barnelementets onClick-handler.
- * Er barnelementet ikke et React-element, rendres det uten sporing.
+ * Eksponerer en spore-handler til render prop-barnet.
+ * Sporing er no-op i DEV-modus / ved opt-out (styres av useAnalytics).
  */
 export function TrackClick({ event, data, children }: TrackClickProps) {
   const { trackEvent } = useAnalytics()
 
-  if (!isValidElement(children)) return <>{children}</>
-
-  const child = children as ClickableElement
-  const originalOnClick = child.props.onClick
-
-  return cloneElement(child, {
-    onClick: (e: MouseEvent) => {
+  const handleClick = useCallback(
+    (_e: MouseEvent) => {
       trackEvent(event, data)
-      originalOnClick?.(e)
     },
-  })
+    [trackEvent, event, data]
+  )
+
+  return <>{children(handleClick)}</>
 }


### PR DESCRIPTION
Fixes #195

## Endringer

Migrerer `TrackClick` fra `React.cloneElement` til render prop-mønster som anbefalt i React 19.

**Breaking change:** `children`-prop endres fra `ReactNode` til `(onClick: (e: MouseEvent) => void) => ReactNode`.

### Gammel API:
```tsx
<TrackClick event="cta.klikk">
  <Button onClick={minHandler}>Klikk</Button>
</TrackClick>
```

### Ny API:
```tsx
<TrackClick event="cta.klikk">
  {(onClick) => <Button onClick={onClick}>Klikk</Button>}
</TrackClick>

// Med egen klikk-logikk i tillegg:
<TrackClick event="cta.klikk">
  {(track) => <Button onClick={(e) => { track(e); minHandler(e) }}>Klikk</Button>}
</TrackClick>
```

**Viktig ved migrering:** Konsumenten er nå selv ansvarlig for å kjede sin egen `onClick`-logikk. `trackEvent` kalles kun for sporingen — ikke for konsumentens egne sideeffekter.

## Versjon
`1.0.2` → `2.0.0` (semver major — breaking change)