### PR TITLE
Fix #199: add @types/node and include config-exports.test.ts in type-checking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@tommyskogstad/frontend-core",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tommyskogstad/frontend-core",
-      "version": "1.0.2",
+      "version": "2.0.0",
       "license": "PRIVATE",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@tanstack/react-query": "^5.101.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.0.0",
+        "@types/node": "^22.0.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.0.0",
         "eslint": "^10.4.1",
@@ -1207,6 +1208,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -3455,6 +3466,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@tanstack/react-query": "^5.101.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.0.0",
+    "@types/node": "^22.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.0.0",
     "eslint": "^10.4.1",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -6,7 +6,6 @@
   "include": ["src"],
   "exclude": [
     "node_modules",
-    "dist",
-    "src/config/__tests__/config-exports.test.ts"
+    "dist"
   ]
 }


### PR DESCRIPTION
Fixes #199

## Changes
- Added `@types/node` as a devDependency
- Removed explicit exclusion of `src/config/__tests__/config-exports.test.ts` from tsconfig.test.json
- Verified: all tests pass and type-checking is clean

## Verification
✅ Type-checking: `npx tsc --noEmit --project tsconfig.test.json`
✅ Tests: 204 passed (13 test files)