### PR TITLE
Fix #198: add typecheck:test npm script for tsconfig.test.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
+    "typecheck:test": "tsc -p tsconfig.test.json",
     "lint": "eslint src/"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fixes #198

## Summary
- Adds `typecheck:test` script to `package.json` that runs `tsc -p tsconfig.test.json`
- Gives discoverability to the type-check for test config, as a natural prerequisite for the CI step requested in #196

## Test plan
- [ ] `npm run typecheck:test` runs without errors (verified locally — zero type errors)