### PR TITLE
Fix #202 QA: clear all timers on ToastProvider unmount

### DIFF
--- a/dist/context/ToastContext.js
+++ b/dist/context/ToastContext.js
@@ -1,5 +1,5 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import { createContext, useContext, useState, useCallback, useRef } from 'react';
+import { createContext, useContext, useState, useCallback, useRef, useEffect } from 'react';
 const ToastContext = createContext(null);
 /**
  * Tilbyr toast-varsler til hele komponenttreet.
@@ -26,6 +26,12 @@ export function ToastProvider({ children }) {
             timerRef.current.delete(id);
         }
         setToasts(prev => prev.filter(t => t.id !== id));
+    }, []);
+    useEffect(() => {
+        return () => {
+            timerRef.current.forEach(clearTimeout);
+            timerRef.current.clear();
+        };
     }, []);
     return (_jsxs(ToastContext.Provider, { value: { showToast, removeToast }, children: [children, _jsx(ToastContainer, { toasts: toasts, onRemove: removeToast })] }));
 }

--- a/src/context/ToastContext.test.tsx
+++ b/src/context/ToastContext.test.tsx
@@ -210,13 +210,10 @@ describe('ToastContext', () => {
 
     expect(clearTimeoutSpy).toHaveBeenCalled()
 
-    // setTimeout skal ikke kjøre etter removeToast
-    const setToastsCalls = vi.fn()
     act(() => { vi.advanceTimersByTime(8000) })
     expect(screen.queryByText('Avbryt meg')).toBeNull()
 
     clearTimeoutSpy.mockRestore()
-    setToastsCalls.mockRestore()
   })
 
   it('removeToast fjerner kun riktig toast, andre forblir', () => {
@@ -257,5 +254,21 @@ describe('ToastContext', () => {
 
     act(() => { vi.advanceTimersByTime(4000) })
     expect(screen.queryByText('Lang toast')).toBeNull()
+  })
+
+  it('alle timers kanselleres ved unmount av ToastProvider', () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+    function UnmountTest() {
+      const { showToast } = useToast()
+      return <button onClick={() => showToast('Unmount toast', 'info', 5000)}>Vis</button>
+    }
+    const { unmount } = renderWithProvider(<UnmountTest />)
+    act(() => { fireEvent.click(screen.getByText('Vis')) })
+
+    clearTimeoutSpy.mockClear()
+    unmount()
+
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+    clearTimeoutSpy.mockRestore()
   })
 })

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, useRef } from 'react'
+import { createContext, useContext, useState, useCallback, useRef, useEffect } from 'react'
 import type { ReactNode } from 'react'
 
 /** Toast-type for visuell stil og semantikk */
@@ -45,6 +45,13 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       timerRef.current.delete(id)
     }
     setToasts(prev => prev.filter(t => t.id !== id))
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      timerRef.current.forEach(clearTimeout)
+      timerRef.current.clear()
+    }
   }, [])
 
   return (


### PR DESCRIPTION
Oppfølging til #205 (issue #202).

Legger til useEffect-cleanup som avbryter alle aktive timers når ToastProvider unmountes. Fikser også død kode i test og legger til unmount-testcase.

Relatert til #202