### PR TITLE
Fix #215: docs: CLAUDE.md lister vinforalle som konsument-app — arkivert 2026-06-19

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,6 @@ npm run lint             # ESLint
 | styreportal | Multi-tenant (TenantContext) |
 | biologportal | React Query, TOTP, Observer-rolle |
 | maskemester | Claude API-integrasjon, strikkekalkulator |
-| vinforalle | Quiz og anbefalinger |
 | smart-casual | Under oppstart |
 
 ## Konvensjoner


### PR DESCRIPTION
Fixes #215

Automatisk fiks av small-sak via Mistral-agent (aider / mistral/mistral-medium-latest). Del av #1097.