### PR TITLE
Fix #220: docs: CHANGELOG mangler [2.0.0]-innslag — breaking change fra juni 2026 er udokumentert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ og prosjektet folger [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-06-11
+
+### Breaking Changes
+- `TrackClick` children-type endret fra `ReactNode` til render prop `(onClick: (e: MouseEvent) => void) => ReactNode`
+
 ## [1.1.0] - 2026-06-10
 
 ### Lagt til


### PR DESCRIPTION
Fixes #220

Automatisk fiks av small-sak via Mistral-agent (aider / mistral/mistral-medium-latest). Del av #1097.