### PR TITLE
Fix #221: docs: CLAUDE.md modul-tabell bruker feil sti for queryClient — lib/queryClient finnes ikke

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ npm run lint             # ESLint
 | `components/ErrorBoundary` | Styling-agnostisk error boundary | Implementert |
 | `components/ProtectedRoute` | Konfigurerbar med roleCheck callback | Implementert |
 | `context/ToastContext` | ToastProvider + useToast for toast-varsler | Implementert |
-| `lib/queryClient` | Standard QueryClient-config | Implementert |
+| `query/queryClient` | Standard QueryClient-config | Implementert |
 | `lib/formatters` | Dato, valuta, tall | Implementert |
 | `analytics/AnalyticsProvider` | Umami-provider med opt-out og dev-mode | Implementert |
 | `analytics/useAnalytics` | Hook for manuell event-sporing — returnerer `{ trackEvent, identify, reset }` | Implementert |


### PR DESCRIPTION
Fixes #221

Automatisk fiks av small-sak via Mistral-agent (aider / mistral/mistral-medium-latest). Del av #1097.