### PR TITLE
fix: read body.error as fallback in apiClient error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ og prosjektet folger [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fikset
+- `handleErrorResponse()` leser nå `body.error` som fallback hvis `body.message` mangler — matcher grunnmur-backends `StatusPagesConfig`-kontrakt (`{ error }`). `message` foretrekkes fortsatt hvis begge finnes, for bakoverkompatibilitet. Fixes #225.
+
 ## [2.0.0] - 2026-06-11
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ try {
 }
 ```
 
+`error.message` leses fra `body.message`, med fallback til `body.error` —
+grunnmur-backends `StatusPagesConfig` sender `{ error }`, ikke `{ message }`.
+
 ---
 
 ### `createAuthProvider<TUser>(config)`

--- a/dist/api/apiClient.js
+++ b/dist/api/apiClient.js
@@ -89,6 +89,9 @@ export function createApiClient(config) {
     }
     /**
      * Håndter feilresponser. Kaster ApiError med parsed body.
+     *
+     * Feilmelding leses fra body.message, med fallback til body.error
+     * (grunnmur-backends StatusPagesConfig sender { error }).
      */
     async function handleErrorResponse(response) {
         let body;
@@ -97,8 +100,14 @@ export function createApiClient(config) {
             const text = await response.text();
             if (text) {
                 body = JSON.parse(text);
+                // grunnmur-backends StatusPagesConfig sender { error }, ikke { message }.
+                // message foretrekkes for bakoverkompatibilitet med apper som allerede
+                // sender det feltet.
                 if (typeof body?.message === 'string') {
                     message = body.message;
+                }
+                else if (typeof body?.error === 'string') {
+                    message = body.error;
                 }
             }
         }

--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -433,6 +433,38 @@ describe('ApiError', () => {
     }
   })
 
+  it('faller tilbake til body.error hvis body ikke har message-felt (grunnmur-backend-kontrakt)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ error: 'Ugyldig e-post' }, 400, 'Bad Request')
+    )
+
+    const client = createApiClient()
+
+    try {
+      await client.request('/register')
+      expect.fail('Skulle ha kastet ApiError')
+    } catch (e) {
+      const err = e as ApiError
+      expect(err.message).toBe('Ugyldig e-post')
+    }
+  })
+
+  it('foretrekker body.message over body.error hvis begge finnes', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ message: 'Fra message', error: 'Fra error' }, 400, 'Bad Request')
+    )
+
+    const client = createApiClient()
+
+    try {
+      await client.request('/test')
+      expect.fail('Skulle ha kastet ApiError')
+    } catch (e) {
+      const err = e as ApiError
+      expect(err.message).toBe('Fra message')
+    }
+  })
+
   it('har is()-metode for statussjekk', () => {
     const err = new ApiError('test', 429, 'Too Many Requests')
     expect(err.is(429)).toBe(true)

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -162,6 +162,9 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
 
   /**
    * Håndter feilresponser. Kaster ApiError med parsed body.
+   *
+   * Feilmelding leses fra body.message, med fallback til body.error
+   * (grunnmur-backends StatusPagesConfig sender { error }).
    */
   async function handleErrorResponse(response: Response): Promise<never> {
     let body: Record<string, unknown> | undefined
@@ -171,8 +174,13 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
       const text = await response.text()
       if (text) {
         body = JSON.parse(text) as Record<string, unknown>
+        // grunnmur-backends StatusPagesConfig sender { error }, ikke { message }.
+        // message foretrekkes for bakoverkompatibilitet med apper som allerede
+        // sender det feltet.
         if (typeof body?.message === 'string') {
           message = body.message
+        } else if (typeof body?.error === 'string') {
+          message = body.error
         }
       }
     } catch {


### PR DESCRIPTION
## Summary
grunnmur-backend's StatusPagesConfig always responds with `{ error }`, but `handleErrorResponse` only checked `body.message`, so `ApiError.message` fell back to `statusText` ("Bad Request") instead of the actual Norwegian error message. All 4 consumer apps (biologportal, 6810, styreportal, smart-casual) carry a near-identical `mapApiError` workaround because of this.

## Changes
- `handleErrorResponse` now reads `body.message ?? body.error` — `message` still wins if both are present, for backward compatibility with apps that already send `message`.
- Added tests covering the `body.error` fallback and the `message`-wins-when-both-present case.
- README + CHANGELOG updated.
- `dist/` rebuilt and committed.

## Follow-up (not in this PR)
Once this ships, the 4 consumer apps can drop their `mapApiError` wrappers:
- biologportal `apiClient.ts:44-59`
- 6810 `apiClient.ts:27-33`
- styreportal `apiClient.ts:40-47`
- smart-casual `apiClient.ts:33-39`

## Test plan
- [x] `npm run test` — 208/208 passing (2 new tests added)
- [x] `npm run build` — clean, `dist/` committed
- [x] `npm run lint` — clean

Fixes #225

https://claude.ai/code/session_01C3q8pYpd77pAHr5THLqm4T