### PR TITLE
fix: blobRequest drops body silently, add downloadRequest + saveBlob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ og prosjektet folger [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Lagt til
+- `downloadRequest(path, options?)` — som `blobRequest`, men returnerer `{ blob, filename?, headers }` med filnavn parset fra `Content-Disposition` (RFC 5987 `filename*=UTF-8''...` foretrukket, fallback til vanlig `filename="..."`). Fixes #226.
+- `saveBlob(blob, filename)` — helper som laster ned en Blob i nettleseren via objectURL + `<a download>`-klikk, med automatisk opprydding. Fixes #226.
+- `parseContentDispositionFilename(header)` — eksportert standalone for de som vil parse headeren selv. Fixes #226.
+
 ### Fikset
 - `handleErrorResponse()` leser nå `body.error` som fallback hvis `body.message` mangler — matcher grunnmur-backends `StatusPagesConfig`-kontrakt (`{ error }`). `message` foretrekkes fortsatt hvis begge finnes, for bakoverkompatibilitet. Fixes #225.
+- `blobRequest()` serialiserte tidligere `options.body` til intet — muterende blob-requests med body ble sendt uten innhold. Deler nå body/CSRF-bygging med `request()` via ny intern `buildJsonRequestInit()`. Fixes #226.
 
 ## [2.0.0] - 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ const api = createApiClient({
 |--------|-------------|
 | `request<T>(path, options?)` | JSON-request med automatisk CSRF og retry-logikk |
 | `formDataRequest<T>(path, formData, method?)` | FormData-request for filopplasting med retry-logikk |
+| `blobRequest(path, options?)` | Filnedlasting — returnerer `Blob` med full CSRF/401/retry-håndtering |
+| `downloadRequest(path, options?)` | Som `blobRequest`, men returnerer `{ blob, filename?, headers }` — `filename` parses fra `Content-Disposition` |
 | `getCsrfToken()` | Hent gjeldende CSRF-token |
 | `setCsrfToken(token)` | Sett CSRF-token manuelt (memory-mode) |
 | `resetUnauthorizedFlag()` | Resett 401-deduplisering etter re-autentisering |
@@ -123,6 +125,12 @@ await api.request('/users', {
 const formData = new FormData()
 formData.append('file', file)
 await api.formDataRequest('/upload', formData)
+
+// Filnedlasting med filnavn fra Content-Disposition
+import { saveBlob } from '@tommyskogstad/frontend-core'
+
+const { blob, filename } = await api.downloadRequest('/rapport/1.pdf')
+saveBlob(blob, filename ?? 'rapport.pdf')
 ```
 
 **`ApiError`** — strukturert feilklasse:

--- a/dist/api/apiClient.d.ts
+++ b/dist/api/apiClient.d.ts
@@ -2,7 +2,7 @@
  * Konfigurerbar API-klient for Kotlin/Ktor-apper.
  *
  * Håndterer CSRF-tokens (cookie eller in-memory), JSON-serialisering,
- * 401-deduplisering og FormData-opplasting.
+ * 401-deduplisering, FormData-opplasting og blob-nedlasting.
  *
  * @example
  * ```ts
@@ -43,6 +43,15 @@ export interface RequestOptions {
     /** Ekstra headers */
     headers?: Record<string, string>;
 }
+/** Resultat av downloadRequest() — Blob med filnavn utledet fra Content-Disposition */
+export interface DownloadResult {
+    /** Nedlastet innhold */
+    blob: Blob;
+    /** Filnavn parset fra Content-Disposition (RFC 5987 filename* foretrukket), eller undefined hvis header mangler */
+    filename?: string;
+    /** Rå respons-headers, for tilfeller filename ikke dekker */
+    headers: Headers;
+}
 /** API-klient returnert av createApiClient() */
 export interface ApiClient {
     /** Generisk request med JSON-serialisering */
@@ -51,6 +60,8 @@ export interface ApiClient {
     formDataRequest: <T>(path: string, formData: FormData, method?: string) => Promise<T>;
     /** Blob-request for filnedlasting — returnerer Blob med full CSRF/401-håndtering */
     blobRequest: (path: string, options?: RequestOptions) => Promise<Blob>;
+    /** Som blobRequest, men inkluderer filnavn parset fra Content-Disposition */
+    downloadRequest: (path: string, options?: RequestOptions) => Promise<DownloadResult>;
     /** Hent gjeldende CSRF-token */
     getCsrfToken: () => string | null;
     /**
@@ -74,6 +85,19 @@ export declare class ApiError extends Error {
     /** Sjekk om feilen er en spesifikk HTTP-statuskode */
     is(status: number): boolean;
 }
+/**
+ * Parse filnavn fra en Content-Disposition-header.
+ * Foretrekker RFC 5987 `filename*=UTF-8''...` (prosent-enkodet) hvis til
+ * stede — headere kan inneholde begge varianter samtidig, med filename*
+ * som det autoritative feltet. Faller tilbake til vanlig `filename="..."`.
+ * Returnerer undefined hvis header mangler eller ikke inneholder filnavn.
+ */
+export declare function parseContentDispositionFilename(header: string | null): string | undefined;
+/**
+ * Last ned en Blob i nettleseren via en midlertidig objectURL + `<a download>`-klikk.
+ * Rydder alltid opp objectURL-en etterpå, selv om klikket kaster.
+ */
+export declare function saveBlob(blob: Blob, filename: string): void;
 /**
  * Opprett en konfigurerbar API-klient.
  *

--- a/dist/api/apiClient.js
+++ b/dist/api/apiClient.js
@@ -2,7 +2,7 @@
  * Konfigurerbar API-klient for Kotlin/Ktor-apper.
  *
  * Håndterer CSRF-tokens (cookie eller in-memory), JSON-serialisering,
- * 401-deduplisering og FormData-opplasting.
+ * 401-deduplisering, FormData-opplasting og blob-nedlasting.
  *
  * @example
  * ```ts
@@ -51,6 +51,46 @@ function getCookieValue(name) {
     const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${escaped}=([^;]*)`));
     return match ? decodeURIComponent(match[1]) : null;
+}
+/**
+ * Parse filnavn fra en Content-Disposition-header.
+ * Foretrekker RFC 5987 `filename*=UTF-8''...` (prosent-enkodet) hvis til
+ * stede — headere kan inneholde begge varianter samtidig, med filename*
+ * som det autoritative feltet. Faller tilbake til vanlig `filename="..."`.
+ * Returnerer undefined hvis header mangler eller ikke inneholder filnavn.
+ */
+export function parseContentDispositionFilename(header) {
+    if (!header)
+        return undefined;
+    const extended = header.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
+    if (extended) {
+        try {
+            return decodeURIComponent(extended[1].trim());
+        }
+        catch {
+            return extended[1].trim();
+        }
+    }
+    const simple = header.match(/filename\s*=\s*"?([^";]+)"?/i);
+    return simple ? simple[1].trim() : undefined;
+}
+/**
+ * Last ned en Blob i nettleseren via en midlertidig objectURL + `<a download>`-klikk.
+ * Rydder alltid opp objectURL-en etterpå, selv om klikket kaster.
+ */
+export function saveBlob(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    try {
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+    }
+    finally {
+        URL.revokeObjectURL(url);
+    }
 }
 /**
  * Opprett en konfigurerbar API-klient.
@@ -164,23 +204,29 @@ export function createApiClient(config) {
         // Nådd kun hvis maxAttempts er 0 (aldri i praksis siden minimum er 1)
         throw new ApiError('Nettverksfeil — sjekk tilkoblingen', 0, 'NetworkError');
     }
-    async function request(path, options) {
-        const method = (options?.method ?? 'GET').toUpperCase();
+    /**
+     * Bygg method/headers/body felles for request(), blobRequest() og downloadRequest():
+     * CSRF-header på muterende metoder + JSON-serialisering av body.
+     */
+    function buildJsonRequestInit(method, options) {
         const headers = { ...options?.headers };
-        const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1;
-        // CSRF-token på muterende requests
         if (!SAFE_METHODS.has(method)) {
             const token = getCsrfToken();
             if (token) {
                 headers[csrfHeaderName] = token;
             }
         }
-        // Content-Type og body-serialisering
         let body;
         if (options?.body !== undefined) {
             headers['Content-Type'] = 'application/json';
             body = JSON.stringify(options.body);
         }
+        return { headers, body };
+    }
+    async function request(path, options) {
+        const method = (options?.method ?? 'GET').toUpperCase();
+        const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1;
+        const { headers, body } = buildJsonRequestInit(method, options);
         return fetchWithRetry(() => fetch(`${basePath}${path}`, { method, headers, body, credentials: 'include' }), maxAttempts);
     }
     async function formDataRequest(path, formData, method = 'POST') {
@@ -203,20 +249,25 @@ export function createApiClient(config) {
     }
     async function blobRequest(path, options) {
         const method = (options?.method ?? 'GET').toUpperCase();
-        const headers = { ...options?.headers };
         const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1;
-        if (!SAFE_METHODS.has(method)) {
-            const token = getCsrfToken();
-            if (token) {
-                headers[csrfHeaderName] = token;
-            }
-        }
-        return fetchWithRetry(() => fetch(`${basePath}${path}`, { method, headers, credentials: 'include' }), maxAttempts, (response) => response.blob());
+        const { headers, body } = buildJsonRequestInit(method, options);
+        return fetchWithRetry(() => fetch(`${basePath}${path}`, { method, headers, body, credentials: 'include' }), maxAttempts, (response) => response.blob());
+    }
+    async function downloadRequest(path, options) {
+        const method = (options?.method ?? 'GET').toUpperCase();
+        const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1;
+        const { headers, body } = buildJsonRequestInit(method, options);
+        return fetchWithRetry(() => fetch(`${basePath}${path}`, { method, headers, body, credentials: 'include' }), maxAttempts, async (response) => ({
+            blob: await response.blob(),
+            filename: parseContentDispositionFilename(response.headers.get('Content-Disposition')),
+            headers: response.headers,
+        }));
     }
     return {
         request,
         formDataRequest,
         blobRequest,
+        downloadRequest,
         getCsrfToken,
         setCsrfToken,
         resetUnauthorizedFlag,

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5,8 +5,8 @@
  * @see README.md for API-referanse og konfigurasjon
  */
 export declare const VERSION: string;
-export { createApiClient, ApiError } from './api/apiClient';
-export type { ApiClientConfig, RequestOptions, ApiClient } from './api/apiClient';
+export { createApiClient, ApiError, saveBlob, parseContentDispositionFilename } from './api/apiClient';
+export type { ApiClientConfig, RequestOptions, ApiClient, DownloadResult } from './api/apiClient';
 export { createAuthProvider } from './auth/AuthContext';
 export type { AuthContextValue, AuthProviderConfig } from './auth/AuthContext';
 export { createAuthApi } from './auth/authApi';

--- a/dist/index.js
+++ b/dist/index.js
@@ -7,7 +7,7 @@
 import pkg from '../package.json';
 export const VERSION = pkg.version;
 // API-klient
-export { createApiClient, ApiError } from './api/apiClient';
+export { createApiClient, ApiError, saveBlob, parseContentDispositionFilename } from './api/apiClient';
 // Auth
 export { createAuthProvider } from './auth/AuthContext';
 export { createAuthApi } from './auth/authApi';

--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { createApiClient, ApiError } from './apiClient'
+import { createApiClient, ApiError, parseContentDispositionFilename, saveBlob } from './apiClient'
 import type { ApiClient, ApiClientConfig } from './apiClient'
 
 // Mock fetch globalt
@@ -697,6 +697,183 @@ describe('blobRequest', () => {
       expect(err.status).toBe(0)
       expect(err.statusText).toBe('NetworkError')
     }
+  })
+
+  it('serialiserer og sender options.body som JSON (tidligere ble body stille droppet)', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('data', { status: 200 }))
+
+    const client = createApiClient()
+    await client.blobRequest('/rapport', { method: 'POST', body: { filter: 'aktive' } })
+
+    const [, init] = mockFetch.mock.calls[0]
+    expect(init.body).toBe(JSON.stringify({ filter: 'aktive' }))
+    expect(init.headers['Content-Type']).toBe('application/json')
+  })
+
+  it('sender ikke body-relaterte headers når options.body er utelatt', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('data', { status: 200 }))
+
+    const client = createApiClient()
+    await client.blobRequest('/test.pdf', { method: 'POST' })
+
+    const [, init] = mockFetch.mock.calls[0]
+    expect(init.body).toBeUndefined()
+    expect(init.headers['Content-Type']).toBeUndefined()
+  })
+})
+
+// ============================================================
+// Test 11: downloadRequest
+// ============================================================
+describe('downloadRequest', () => {
+  it('returnerer blob, filename og headers ved vellykket respons', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('PDF-innhold', {
+        status: 200,
+        headers: { 'Content-Disposition': 'attachment; filename="rapport.pdf"' },
+      })
+    )
+
+    const client = createApiClient()
+    const result = await client.downloadRequest('/rapport/1.pdf')
+
+    expect(result.blob.constructor.name).toBe('Blob')
+    expect(result.filename).toBe('rapport.pdf')
+    expect(result.headers.get('Content-Disposition')).toContain('rapport.pdf')
+  })
+
+  it('foretrekker RFC 5987 filename* (UTF-8-enkodet)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('data', {
+        status: 200,
+        headers: {
+          'Content-Disposition': "attachment; filename=\"kontrakt.pdf\"; filename*=UTF-8''kontrakt-m%C3%B8te.pdf",
+        },
+      })
+    )
+
+    const client = createApiClient()
+    const result = await client.downloadRequest('/kontrakt.pdf')
+
+    expect(result.filename).toBe('kontrakt-møte.pdf')
+  })
+
+  it('filename er undefined hvis Content-Disposition mangler', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('data', { status: 200 }))
+
+    const client = createApiClient()
+    const result = await client.downloadRequest('/uten-header.pdf')
+
+    expect(result.filename).toBeUndefined()
+  })
+
+  it('serialiserer og sender options.body som JSON', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('data', { status: 200 }))
+
+    const client = createApiClient()
+    await client.downloadRequest('/generer.pdf', { method: 'POST', body: { id: 42 } })
+
+    const [, init] = mockFetch.mock.calls[0]
+    expect(init.body).toBe(JSON.stringify({ id: 42 }))
+    expect(init.headers['Content-Type']).toBe('application/json')
+  })
+
+  it('sender CSRF-header på muterende metoder', async () => {
+    document.cookie = 'csrf_token=download-csrf'
+    mockFetch.mockResolvedValueOnce(new Response('data', { status: 200 }))
+
+    const client = createApiClient()
+    await client.downloadRequest('/generer.pdf', { method: 'POST' })
+
+    const [, init] = mockFetch.mock.calls[0]
+    expect(init.headers['X-CSRF-Token']).toBe('download-csrf')
+  })
+
+  it('kaster ApiError ved feilrespons', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ error: 'Fil ikke funnet' }, 404, 'Not Found')
+    )
+
+    const client = createApiClient()
+
+    await expect(client.downloadRequest('/mangler.pdf')).rejects.toBeInstanceOf(ApiError)
+  })
+})
+
+// ============================================================
+// Test 12: parseContentDispositionFilename
+// ============================================================
+describe('parseContentDispositionFilename', () => {
+  it('parser vanlig filename="..."', () => {
+    expect(parseContentDispositionFilename('attachment; filename="rapport.pdf"')).toBe('rapport.pdf')
+  })
+
+  it('parser filename uten anførselstegn', () => {
+    expect(parseContentDispositionFilename('attachment; filename=rapport.pdf')).toBe('rapport.pdf')
+  })
+
+  it('parser RFC 5987 filename*=UTF-8\'\'... og dekoder prosent-enkoding', () => {
+    expect(
+      parseContentDispositionFilename("attachment; filename*=UTF-8''kontrakt-m%C3%B8te.pdf")
+    ).toBe('kontrakt-møte.pdf')
+  })
+
+  it('returnerer undefined for null-header', () => {
+    expect(parseContentDispositionFilename(null)).toBeUndefined()
+  })
+
+  it('returnerer undefined hvis header ikke inneholder filename', () => {
+    expect(parseContentDispositionFilename('inline')).toBeUndefined()
+  })
+})
+
+// ============================================================
+// Test 13: saveBlob
+// ============================================================
+describe('saveBlob', () => {
+  it('oppretter objectURL, klikker en <a download> og rydder opp URL-en etterpå', () => {
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock-url')
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL })
+
+    const clickSpy = vi.fn()
+    const originalCreateElement = document.createElement.bind(document)
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = originalCreateElement(tag)
+      if (tag === 'a') el.click = clickSpy
+      return el
+    })
+
+    const blob = new Blob(['data'])
+    saveBlob(blob, 'test.pdf')
+
+    expect(createObjectURL).toHaveBeenCalledWith(blob)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+
+    createElementSpy.mockRestore()
+  })
+
+  it('rydder opp objectURL selv om klikket kaster', () => {
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock-url')
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL })
+
+    const originalCreateElement = document.createElement.bind(document)
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = originalCreateElement(tag)
+      if (tag === 'a') {
+        el.click = () => {
+          throw new Error('klikk-feil')
+        }
+      }
+      return el
+    })
+
+    expect(() => saveBlob(new Blob(['data']), 'test.pdf')).toThrow('klikk-feil')
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+
+    createElementSpy.mockRestore()
   })
 })
 

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -2,7 +2,7 @@
  * Konfigurerbar API-klient for Kotlin/Ktor-apper.
  *
  * Håndterer CSRF-tokens (cookie eller in-memory), JSON-serialisering,
- * 401-deduplisering og FormData-opplasting.
+ * 401-deduplisering, FormData-opplasting og blob-nedlasting.
  *
  * @example
  * ```ts
@@ -46,6 +46,16 @@ export interface RequestOptions {
   headers?: Record<string, string>
 }
 
+/** Resultat av downloadRequest() — Blob med filnavn utledet fra Content-Disposition */
+export interface DownloadResult {
+  /** Nedlastet innhold */
+  blob: Blob
+  /** Filnavn parset fra Content-Disposition (RFC 5987 filename* foretrukket), eller undefined hvis header mangler */
+  filename?: string
+  /** Rå respons-headers, for tilfeller filename ikke dekker */
+  headers: Headers
+}
+
 /** API-klient returnert av createApiClient() */
 export interface ApiClient {
   /** Generisk request med JSON-serialisering */
@@ -54,6 +64,8 @@ export interface ApiClient {
   formDataRequest: <T>(path: string, formData: FormData, method?: string) => Promise<T>
   /** Blob-request for filnedlasting — returnerer Blob med full CSRF/401-håndtering */
   blobRequest: (path: string, options?: RequestOptions) => Promise<Blob>
+  /** Som blobRequest, men inkluderer filnavn parset fra Content-Disposition */
+  downloadRequest: (path: string, options?: RequestOptions) => Promise<DownloadResult>
   /** Hent gjeldende CSRF-token */
   getCsrfToken: () => string | null
   /**
@@ -115,6 +127,47 @@ function getCookieValue(name: string): string | null {
     new RegExp(`(?:^|;\\s*)${escaped}=([^;]*)`)
   )
   return match ? decodeURIComponent(match[1]) : null
+}
+
+/**
+ * Parse filnavn fra en Content-Disposition-header.
+ * Foretrekker RFC 5987 `filename*=UTF-8''...` (prosent-enkodet) hvis til
+ * stede — headere kan inneholde begge varianter samtidig, med filename*
+ * som det autoritative feltet. Faller tilbake til vanlig `filename="..."`.
+ * Returnerer undefined hvis header mangler eller ikke inneholder filnavn.
+ */
+export function parseContentDispositionFilename(header: string | null): string | undefined {
+  if (!header) return undefined
+
+  const extended = header.match(/filename\*\s*=\s*UTF-8''([^;]+)/i)
+  if (extended) {
+    try {
+      return decodeURIComponent(extended[1].trim())
+    } catch {
+      return extended[1].trim()
+    }
+  }
+
+  const simple = header.match(/filename\s*=\s*"?([^";]+)"?/i)
+  return simple ? simple[1].trim() : undefined
+}
+
+/**
+ * Last ned en Blob i nettleseren via en midlertidig objectURL + `<a download>`-klikk.
+ * Rydder alltid opp objectURL-en etterpå, selv om klikket kaster.
+ */
+export function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  try {
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+  } finally {
+    URL.revokeObjectURL(url)
+  }
 }
 
 /**
@@ -255,12 +308,16 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
     throw new ApiError('Nettverksfeil — sjekk tilkoblingen', 0, 'NetworkError')
   }
 
-  async function request<T>(path: string, options?: RequestOptions): Promise<T> {
-    const method = (options?.method ?? 'GET').toUpperCase()
+  /**
+   * Bygg method/headers/body felles for request(), blobRequest() og downloadRequest():
+   * CSRF-header på muterende metoder + JSON-serialisering av body.
+   */
+  function buildJsonRequestInit(
+    method: string,
+    options?: RequestOptions
+  ): { headers: Record<string, string>; body?: string } {
     const headers: Record<string, string> = { ...options?.headers }
-    const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1
 
-    // CSRF-token på muterende requests
     if (!SAFE_METHODS.has(method)) {
       const token = getCsrfToken()
       if (token) {
@@ -268,12 +325,19 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
       }
     }
 
-    // Content-Type og body-serialisering
     let body: string | undefined
     if (options?.body !== undefined) {
       headers['Content-Type'] = 'application/json'
       body = JSON.stringify(options.body)
     }
+
+    return { headers, body }
+  }
+
+  async function request<T>(path: string, options?: RequestOptions): Promise<T> {
+    const method = (options?.method ?? 'GET').toUpperCase()
+    const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1
+    const { headers, body } = buildJsonRequestInit(method, options)
 
     return fetchWithRetry<T>(
       () => fetch(`${basePath}${path}`, { method, headers, body, credentials: 'include' }),
@@ -311,20 +375,29 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
 
   async function blobRequest(path: string, options?: RequestOptions): Promise<Blob> {
     const method = (options?.method ?? 'GET').toUpperCase()
-    const headers: Record<string, string> = { ...options?.headers }
     const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1
-
-    if (!SAFE_METHODS.has(method)) {
-      const token = getCsrfToken()
-      if (token) {
-        headers[csrfHeaderName] = token
-      }
-    }
+    const { headers, body } = buildJsonRequestInit(method, options)
 
     return fetchWithRetry<Blob>(
-      () => fetch(`${basePath}${path}`, { method, headers, credentials: 'include' }),
+      () => fetch(`${basePath}${path}`, { method, headers, body, credentials: 'include' }),
       maxAttempts,
       (response) => response.blob()
+    )
+  }
+
+  async function downloadRequest(path: string, options?: RequestOptions): Promise<DownloadResult> {
+    const method = (options?.method ?? 'GET').toUpperCase()
+    const maxAttempts = SAFE_METHODS.has(method) ? 1 + retryCount : 1
+    const { headers, body } = buildJsonRequestInit(method, options)
+
+    return fetchWithRetry<DownloadResult>(
+      () => fetch(`${basePath}${path}`, { method, headers, body, credentials: 'include' }),
+      maxAttempts,
+      async (response) => ({
+        blob: await response.blob(),
+        filename: parseContentDispositionFilename(response.headers.get('Content-Disposition')),
+        headers: response.headers,
+      })
     )
   }
 
@@ -332,6 +405,7 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
     request,
     formDataRequest,
     blobRequest,
+    downloadRequest,
     getCsrfToken,
     setCsrfToken,
     resetUnauthorizedFlag,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ import pkg from '../package.json'
 export const VERSION = pkg.version
 
 // API-klient
-export { createApiClient, ApiError } from './api/apiClient'
-export type { ApiClientConfig, RequestOptions, ApiClient } from './api/apiClient'
+export { createApiClient, ApiError, saveBlob, parseContentDispositionFilename } from './api/apiClient'
+export type { ApiClientConfig, RequestOptions, ApiClient, DownloadResult } from './api/apiClient'
 
 // Auth
 export { createAuthProvider } from './auth/AuthContext'


### PR DESCRIPTION
## Summary
1. **Bug**: `blobRequest('/rapport', { method: 'POST', body: {...} })` sent an empty body — the signature accepted `RequestOptions.body` and set the CSRF header, but the fetch call at `apiClient.ts:317` (old line) never serialized/sent `body`.
2. **API gap**: `blobRequest` only ever returned a bare `Blob`, with no way to read the filename from `Content-Disposition`. That's the main reason biologportal kept its own `apiRawRequest` + `downloadBlob`-style RFC 5987 parsing, and styreportal/6810 hand-roll their own download code with raw fetch (no retry/401 handling).

## Changes
- Extracted the CSRF-header + JSON-body-serialization logic shared between `request()` and `blobRequest()` into a new internal `buildJsonRequestInit()` — this is also the actual fix for the body bug, and prevents the same class of bug from being reintroduced in a third method.
- New `downloadRequest(path, options?)` → `Promise<{ blob, filename?, headers }>`. `filename` is parsed by `parseContentDispositionFilename()`, preferring RFC 5987 `filename*=UTF-8''...` over plain `filename="..."` when both are present.
- New `saveBlob(blob, filename)` helper — objectURL + `<a download>` + click + revoke, wrapped in try/finally so the URL is always revoked even if the click throws.
- Both `parseContentDispositionFilename` and `saveBlob` are exported standalone.
- README + CHANGELOG updated, `dist/` rebuilt and committed.

`blobRequest`'s existing signature/behavior is unchanged for GET/no-body callers — grep confirms 0 current consumers across the 4 apps, so this is safe to ship without a major bump.

## Follow-up (not in this PR)
- styreportal's `signatures.ts:20-32` (raw fetch, no retry/401) is a good first migration target to `downloadRequest` + `saveBlob`.
- biologportal's `apiRawRequest` + inline filename parsing in `contracts.ts`/`frilansContracts.ts`/`gdpr.ts` could be dropped in favor of `downloadRequest`.

## Test plan
- [x] `npm run test` — 223/223 passing (15 new tests: body-serialization on `blobRequest`, `downloadRequest` behavior, `parseContentDispositionFilename` edge cases, `saveBlob` cleanup incl. throw-safety)
- [x] `npm run build` — clean, `dist/` committed
- [x] `npm run lint` — clean

Fixes #226

https://claude.ai/code/session_01C3q8pYpd77pAHr5THLqm4T