### PR TITLE
feat: add formatDateLong for long-form Norwegian dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ og prosjektet folger [Semantic Versioning](https://semver.org/).
 - `usePageView({ transformUrl? })` — ny valgfri opsjon for å transformere pathname før sending (f.eks. anonymisere ID-er/tokens), fanget via ref slik at en ustabil inline-funksjon ikke trigger track() på hver render. Fixes #228.
 - `anonymizePathname(pathname)` — eksportert helper for `transformUrl`; superset av tall/UUID → `:id` og lange hex-strenger (32/64 tegn, kontrakt-/delingslenke-tokens) → `:token`. Fixes #228.
 - `useAnalyticsIdentity(user, traits?)` og `AnalyticsIdentitySync` (tynn komponent-wrapper) — holder Umami-sesjon synkronisert med innlogget bruker (`identify(user.id, traits)` ved innlogging, `reset()` ved utlogging), med `console.warn` i stedet for kast ved feil. Fixes #228.
+- `formatDateLong(date)` — formaterer dato med lang manedsform: `"5. januar 2026"`. Dekker hullet som fikk 6810 til å redefinere hele formatDate-familien lokalt. Fixes #229.
 
 ### Dokumentert
 - Presisert pageview-semantikk: `usePageView()` kaller Umamis native `track({ url })` (ekte sidevisning), mens `useAnalytics().trackEvent('pageview', {...})` kaller `track(eventName, data)` og registreres som en *custom event* — ikke en sidevisning. README advarer nå eksplisitt mot å bruke `trackEvent` til sidevisninger. Fixes #228.

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Norske formatters som bruker `nb-NO` locale via Intl API-er.
 import {
   formatCurrency,
   formatDate,
+  formatDateLong,
   formatDateTime,
   formatNumber,
   formatFileSize,
@@ -418,6 +419,7 @@ import {
 |----------|---------------|-----------------|
 | `formatCurrency(amount)` | `1234.5` | `kr 1 234,50` |
 | `formatDate(date)` | `'2026-04-08'` | `08.04.2026` |
+| `formatDateLong(date)` | `'2026-01-05'` | `5. januar 2026` |
 | `formatDateTime(date)` | `'2026-04-08T14:30:00'` | `08.04.2026, 14:30` |
 | `formatNumber(num, decimals?)` | `1234567, 2` | `1 234 567,00` |
 | `formatFileSize(bytes)` | `1536` | `1,5 KB` |

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -16,7 +16,7 @@ export type { ErrorBoundaryProps } from './components/ErrorBoundary';
 export { createProtectedRoute } from './components/ProtectedRoute';
 export type { ProtectedRouteProps } from './components/ProtectedRoute';
 export { createQueryClient } from './query/queryClient';
-export { formatCurrency, formatDate, formatDateTime, formatNumber, formatFileSize, relativeTime } from './lib/formatters';
+export { formatCurrency, formatDate, formatDateLong, formatDateTime, formatNumber, formatFileSize, relativeTime } from './lib/formatters';
 export { ToastProvider } from './context/ToastContext';
 export { useToast } from './context/toastContext';
 export type { ToastType, ToastContextValue } from './context/toastContext';

--- a/dist/index.js
+++ b/dist/index.js
@@ -17,7 +17,7 @@ export { createProtectedRoute } from './components/ProtectedRoute';
 // Query
 export { createQueryClient } from './query/queryClient';
 // Formatters
-export { formatCurrency, formatDate, formatDateTime, formatNumber, formatFileSize, relativeTime } from './lib/formatters';
+export { formatCurrency, formatDate, formatDateLong, formatDateTime, formatNumber, formatFileSize, relativeTime } from './lib/formatters';
 // Context
 export { ToastProvider } from './context/ToastContext';
 export { useToast } from './context/toastContext';

--- a/dist/lib/formatters.d.ts
+++ b/dist/lib/formatters.d.ts
@@ -14,6 +14,8 @@
 export declare function formatCurrency(amount: number): string;
 /** Formaterer dato: "08.04.2026" */
 export declare function formatDate(date: string | Date): string;
+/** Formaterer dato med lang manedsform: "5. januar 2026" */
+export declare function formatDateLong(date: string | Date): string;
 /** Formaterer dato med klokkeslett: "08.04.2026, 14:30" */
 export declare function formatDateTime(date: string | Date): string;
 /** Formaterer tall med norsk tusenskilletegn og valgfritt antall desimaler */

--- a/dist/lib/formatters.js
+++ b/dist/lib/formatters.js
@@ -15,6 +15,7 @@ const DASH = '–'; // tankestrek (–)
 // Lazy-initialiserte Intl-formatters for ytelse
 let currencyFmt;
 let dateFmt;
+let dateLongFmt;
 let dateTimeFmt;
 let relativeFmt;
 /** Maks antall entries i numberFmtCache — FIFO-purge ved overskridelse */
@@ -40,6 +41,14 @@ export function formatDate(date) {
         return DASH;
     dateFmt ?? (dateFmt = new Intl.DateTimeFormat(LOCALE, { day: '2-digit', month: '2-digit', year: 'numeric' }));
     return dateFmt.format(d);
+}
+/** Formaterer dato med lang manedsform: "5. januar 2026" */
+export function formatDateLong(date) {
+    const d = toDate(date);
+    if (!d)
+        return DASH;
+    dateLongFmt ?? (dateLongFmt = new Intl.DateTimeFormat(LOCALE, { day: 'numeric', month: 'long', year: 'numeric' }));
+    return dateLongFmt.format(d);
 }
 /** Formaterer dato med klokkeslett: "08.04.2026, 14:30" */
 export function formatDateTime(date) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export { createQueryClient } from './query/queryClient'
 export {
   formatCurrency,
   formatDate,
+  formatDateLong,
   formatDateTime,
   formatNumber,
   formatFileSize,

--- a/src/lib/__tests__/formatters.test.ts
+++ b/src/lib/__tests__/formatters.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   formatCurrency,
   formatDate,
+  formatDateLong,
   formatDateTime,
   formatNumber,
   formatFileSize,
@@ -59,6 +60,33 @@ describe('formatDate', () => {
 
   it('returnerer tankestrek for undefined', () => {
     expect(formatDate(undefined as unknown as string)).toBe('\u2013')
+  })
+})
+
+describe('formatDateLong', () => {
+  it('formaterer ISO-streng til dag. maaned aar', () => {
+    expect(formatDateLong('2026-01-05')).toBe('5. januar 2026')
+  })
+
+  it('formaterer Date-objekt', () => {
+    const date = new Date(2026, 10, 25) // november = 10 (0-indeksert)
+    expect(formatDateLong(date)).toBe('25. november 2026')
+  })
+
+  it('bruker ikke ledende null paa dagtallet', () => {
+    expect(formatDateLong('2026-04-08')).toBe('8. april 2026')
+  })
+
+  it('returnerer tankestrek for ugyldig dato', () => {
+    expect(formatDateLong('ugyldig')).toBe('–')
+  })
+
+  it('returnerer tankestrek for null', () => {
+    expect(formatDateLong(null as unknown as string)).toBe('–')
+  })
+
+  it('returnerer tankestrek for undefined', () => {
+    expect(formatDateLong(undefined as unknown as string)).toBe('–')
   })
 })
 

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -17,6 +17,7 @@ const DASH = '–' // tankestrek (–)
 // Lazy-initialiserte Intl-formatters for ytelse
 let currencyFmt: Intl.NumberFormat
 let dateFmt: Intl.DateTimeFormat
+let dateLongFmt: Intl.DateTimeFormat
 let dateTimeFmt: Intl.DateTimeFormat
 let relativeFmt: Intl.RelativeTimeFormat
 
@@ -43,6 +44,14 @@ export function formatDate(date: string | Date): string {
   if (!d) return DASH
   dateFmt ??= new Intl.DateTimeFormat(LOCALE, { day: '2-digit', month: '2-digit', year: 'numeric' })
   return dateFmt.format(d)
+}
+
+/** Formaterer dato med lang manedsform: "5. januar 2026" */
+export function formatDateLong(date: string | Date): string {
+  const d = toDate(date)
+  if (!d) return DASH
+  dateLongFmt ??= new Intl.DateTimeFormat(LOCALE, { day: 'numeric', month: 'long', year: 'numeric' })
+  return dateLongFmt.format(d)
 }
 
 /** Formaterer dato med klokkeslett: "08.04.2026, 14:30" */


### PR DESCRIPTION
## Summary
6810's `frontend/src/lib/formatters.ts` redefines `formatDate` ("5. januar 2026"), `formatFileSize` and `relativeTime` with divergent output ("1.5 KB" with a period vs. grunnmur's nb-NO "1,5 KB"; "2t siden" vs. "for 2 timer siden"). The `formatFileSize`/`relativeTime` duplication is pure drift, but the `formatDate` duplicate reflects a real gap: grunnmur only had numeric-format dates ("08.04.2026"), no long-form for content pages that need it.

## Changes
- `formatDateLong(date)` — `"5. januar 2026"` via `Intl.DateTimeFormat('nb-NO', { day: 'numeric', month: 'long', year: 'numeric' })`, following the module's existing lazy-cached-formatter pattern (`dateLongFmt ??= ...`).
- Exported from `src/index.ts`, documented in README with the same example-table format as the other formatters.

6810's deliberate short forms (`formatFileSize` without a comma-decimal, `relativeTime`'s `"2t siden"`) stay local by design, per the issue text — this PR only closes the `formatDateLong` gap, it doesn't touch `relativeTime`'s style param (mentioned as an optional "ev." in the issue, not a required AC).

## Follow-up (not in this PR)
Per grunnmur-frontend's cross-repo boundary, this PR doesn't touch 6810. I'll open a follow-up issue there to migrate `formatDate` + `formatFileSize` to grunnmur's versions and drop the local duplicates, keeping only the deliberate short-form `relativeTime`.

## Test plan
- [x] `npm run test` — 265/265 passing (6 new tests: ISO string, Date object, no leading zero on day, invalid/null/undefined → dash)
- [x] `npm run build` — clean, `dist/` committed
- [x] `npm run lint` — clean

Fixes #229

https://claude.ai/code/session_01C3q8pYpd77pAHr5THLqm4T