### PR TITLE
Fix #235: bump undici 7.25.0 → 7.28.0 (patch HIGH CVEs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3491,9 +3491,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Fixes #235

## Hva
Bumper `undici` 7.25.0 → **7.28.0** i `package-lock.json`.

## Hvorfor
`undici@7.25.0` er en **dev-only transitiv avhengighet** (`"dev": true`), dratt inn av `jsdom@29.1.1` (`undici: ^7.25.0`) og brukt av vitest for DOM-testing. Den shippes aldri til konsumenter i runtime.

npm/GitHub Advisory DB bekrefter at alle de flaggede rådgivningene er fikset i **undici 7.28.0**, bl.a.:
- GHSA-hm92-r4w5-c3mj (HIGH — cross-origin request routing via SOCKS5 proxy pool reuse)
- GHSA-vmh5-mc38-953g (HIGH — TLS cert validation bypass i SOCKS5 ProxyAgent)
- GHSA-vxpw-j846-p89q (HIGH — WebSocket DoS via fragment count bypass)
- \+ moderate/low (Set-Cookie, keep-alive queue poisoning m.fl.)

## Omfang
- 7.28.0 ligger innenfor jsdom sin `^7.25.0`-range → **kun lockfile endres**, `package.json` er urørt (ingen `overrides` nødvendig).
- Diff: 3 linjer (version/resolved/integrity).

## Verifisering
- `npm ls undici`: 7.25.0 → **7.28.0**
- `npm audit`: 1 HIGH undici-funn → **0 undici-funn**
- `npm run build`: dist/ uendret
- `npm test`: **265/265 grønne**

Merk: en separat LOW `@babel/core`-sak i `npm audit` er utenfor scope for #235 og røres ikke her.