### PR TITLE
Fix #245: docs: vinforalle gjenoppstått som konsument av frontend-core — ikke listet i README/CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ npm run lint             # ESLint
 | biologportal | React Query, TOTP, Observer-rolle |
 | maskemester | Claude API-integrasjon, strikkekalkulator |
 | smart-casual | Under oppstart |
+| vinforalle | Under oppstart |
 
 ## Konvensjoner
 


### PR DESCRIPTION
Fixes #245

Automatisk fiks av small-sak via Mistral-agent (aider / mistral/mistral-medium-latest). Del av #1097.