### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ og prosjektet folger [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-03
+
 ### Lagt til
 - `downloadRequest(path, options?)` — som `blobRequest`, men returnerer `{ blob, filename?, headers }` med filnavn parset fra `Content-Disposition` (RFC 5987 `filename*=UTF-8''...` foretrukket, fallback til vanlig `filename="..."`). Fixes #226.
 - `saveBlob(blob, filename)` — helper som laster ned en Blob i nettleseren via objectURL + `<a download>`-klikk, med automatisk opprydding. Fixes #226.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tommyskogstad/frontend-core",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Felles frontend-bibliotek for Kotlin/Ktor-apper",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Fixes #249

## Endringer
- Bumped `package.json` versjon fra 2.0.0 til 2.1.0 (minor — nye features siden 2026-06-11)
- Flyttet `[Unreleased]` til `[2.1.0] - 2026-07-03` i CHANGELOG.md

## Kontekst
5 nye commits siden siste release (2026-06-11) under [Unreleased]:
- #225, #226: fiks i apiClient/blobRequest
- #227: nye useIssueReport hook
- #228: analytics-identitet + pageview-transformasjon
- #229: formatDateLong

Alle symboer er implementert og dokumentert i CLAUDE.md.