### PR TITLE
security: bump brace-expansion to ^5.0.8 (closes #251)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tommyskogstad/frontend-core",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tommyskogstad/frontend-core",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "PRIVATE",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1717,16 +1717,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "typescript-eslint": "^8.64.0",
     "vitest": "^4.1.10"
   },
+  "overrides": {
+    "brace-expansion": "^5.0.8"
+  },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },


### PR DESCRIPTION
Fixes #251

## Hva ble gjort
- Lagt til override for brace-expansion til ^5.0.8 i package.json
- Kjørt npm install --package-lock-only for å oppdatere package-lock.json
- Verifisert at npm audit ikke lenger viser brace-expansion DoS-sårbarhet
- Full testsuite passerer (265 tester, 17 test-filer)

## Sårbarhet som fikses
- GHSA-3jxr-9vmj-r5cp — DoS via eksponentiell-tid expansion
- GHSA-mh99-v99m-4gvg — DoS via ubegrenset expansion-lengde (OOM)

## Test-resultat
- ✅ npm audit: brace-expansion sårbarhet borte
- ✅ npm run test: alle 265 tester passerer