### PR TITLE
Fix #257: migrate react-router-dom peer/devDependency to react-router (v8-ready)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ og prosjektet folger [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Endret
+- `peerDependencies`/`devDependencies` bytter fra `react-router-dom` til `react-router` (`^7.0.0 || ^8.0.0`) — `react-router-dom` er en re-export-shim som fjernes i react-router v8, mens `react-router` er den stabile pakken som allerede er installert transitivt i alle konsumentapper via `react-router-dom@7.x`. Ikke-brytende for eksisterende apper. Intern bruk (`usePageView.ts`, `ProtectedRoute.tsx`) oppdatert tilsvarende. Merk: `react-router@8.3.0` selv krever `react >=19.2.7`, strengere enn grunnmurs egen `react`-peer-range (`^18.0.0 || ^19.0.0`) — apper fortsatt på React 18 (biologportal, 6810, styreportal) kan dermed kun bruke `^7.0.0`-delen av rangen inntil de også oppgraderer React. Fixes #257.
+
 ## [2.1.0] - 2026-07-03
 
 ### Lagt til

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,11 +112,15 @@ React-instanser i bundlet (en fra grunnmurs node_modules, en fra konsumentens
 egen) — og alle hooks fra grunnmur (AuthProvider, ErrorBoundary etc.) krasjer
 med `Cannot read properties of null (reading 'useState')` på initial render.
 
-**Versjonskrav:** Grunnmur KREVER `react-router-dom` ^7.0 og støtter ikke v6.
-Konsumentapper må derfor også bruke v7. Historisk ble v6-kompatibilitet droppet
-i #135 fordi grunnmurs `ProtectedRoute` bruker v7-spesifikke features (`Outlet`/`Navigate`).
-Se issue #26 for bakgrunnen på den tidligere v6/v7-dobbel-instansmeldingen
-(biologportal-incident 2026-04-10, nå løst).
+**Versjonskrav:** Grunnmur krever peer-pakken `react-router` (ikke lenger
+`react-router-dom`, som er en re-export-shim fjernet i react-router v8 — se
+#257) i range `^7.0.0 || ^8.0.0`, og støtter ikke v6. Konsumentapper som
+fortsatt bruker `react-router-dom` v7 er upåvirket: `react-router-dom@7.x` har
+`react-router@7.x` som intern dependency, hoistet i node_modules — samme
+fysiske modul grunnmur nå importerer fra. Historisk ble v6-kompatibilitet
+droppet i #135 fordi grunnmurs `ProtectedRoute` bruker v7-spesifikke features
+(`Outlet`/`Navigate`). Se issue #26 for bakgrunnen på den tidligere
+v6/v7-dobbel-instansmeldingen (biologportal-incident 2026-04-10, nå løst).
 
 React-incidenten (runde 1) traff biologportal og lo-finans 2026-04-10 — fire
 påfølgende deploys i biologportal feilet smoke-test [7/7] før rotårsaken ble

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Pakken krever disse som peer dependencies:
 |-------|---------|-------------|
 | `react` | ^18.0 \|\| ^19.0 | Ja |
 | `react-dom` | ^18.0 \|\| ^19.0 | Ja |
-| `react-router-dom` | ^7.0 | Ja |
+| `react-router` | ^7.0 \|\| ^8.0 | Ja |
 | `@tanstack/react-query` | ^5.0 | Valgfritt |
 
 ## Quick start
@@ -546,7 +546,7 @@ function App() {
 }
 ```
 
-Kaller `window.umami.track({ url: location.pathname })` ved hver pathname-endring — dette er Umamis native pageview-API og gir en ekte sidevisning i dashbordet (se advarselen under `useAnalytics()` over). Krever at komponenten er innenfor en `react-router-dom` Router. Er no-op dersom tracking er deaktivert.
+Kaller `window.umami.track({ url: location.pathname })` ved hver pathname-endring — dette er Umamis native pageview-API og gir en ekte sidevisning i dashbordet (se advarselen under `useAnalytics()` over). Krever at komponenten er innenfor en `react-router` Router. Er no-op dersom tracking er deaktivert.
 
 **Anonymiser dynamiske ID-er/tokens i stien** med `transformUrl` + den medfølgende `anonymizePathname`-helperen (superset av tall/UUID → `:id` og lange hex-strenger → `:token`):
 

--- a/dist/analytics/usePageView.d.ts
+++ b/dist/analytics/usePageView.d.ts
@@ -1,7 +1,7 @@
 /**
  * usePageView — sporer SPA-sidevisninger ved navigasjon med React Router.
  *
- * Krever at komponenten er innenfor en react-router-dom Router.
+ * Krever at komponenten er innenfor en react-router Router.
  *
  * **Semantikk:** Kaller `window.umami.track({ url })` — Umamis native
  * pageview-API. Dette registreres som en ekte sidevisning i Umami-

--- a/dist/analytics/usePageView.js
+++ b/dist/analytics/usePageView.js
@@ -1,7 +1,7 @@
 /**
  * usePageView — sporer SPA-sidevisninger ved navigasjon med React Router.
  *
- * Krever at komponenten er innenfor en react-router-dom Router.
+ * Krever at komponenten er innenfor en react-router Router.
  *
  * **Semantikk:** Kaller `window.umami.track({ url })` — Umamis native
  * pageview-API. Dette registreres som en ekte sidevisning i Umami-
@@ -29,7 +29,7 @@
  * ```
  */
 import { useEffect, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useAnalyticsContext } from './analyticsContext';
 /**
  * Kaller window.umami.track({ url }) ved pathname-endringer.

--- a/dist/components/ProtectedRoute.js
+++ b/dist/components/ProtectedRoute.js
@@ -1,5 +1,5 @@
 import { Fragment as _Fragment, jsx as _jsx } from "react/jsx-runtime";
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router';
 /**
  * Opprett en ProtectedRoute-komponent bundet til en spesifikk useAuth-hook.
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "jsdom": "^29.1.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.65.0",
         "vitest": "^4.1.10"
@@ -32,7 +32,7 @@
         "@tanstack/react-query": "^5.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
-        "react-router-dom": "^7.0.0"
+        "react-router": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@tanstack/react-query": {
@@ -1801,19 +1801,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3147,43 +3140,25 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/require-from-string": {
@@ -3259,13 +3234,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "react-router-dom": "^7.0.0",
+    "react-router": "^7.0.0 || ^8.0.0",
     "@tanstack/react-query": "^5.0.0"
   },
   "peerDependenciesMeta": {
@@ -51,7 +51,7 @@
     "jsdom": "^29.1.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0",
     "vitest": "^4.1.10"

--- a/src/analytics/usePageView.test.tsx
+++ b/src/analytics/usePageView.test.tsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { useState } from 'react'
 import { render, act, cleanup } from '@testing-library/react'
-import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router'
 import { usePageView } from './usePageView'
 import type { UsePageViewOptions } from './usePageView'
 import { AnalyticsProvider } from './AnalyticsProvider'

--- a/src/analytics/usePageView.ts
+++ b/src/analytics/usePageView.ts
@@ -1,7 +1,7 @@
 /**
  * usePageView — sporer SPA-sidevisninger ved navigasjon med React Router.
  *
- * Krever at komponenten er innenfor en react-router-dom Router.
+ * Krever at komponenten er innenfor en react-router Router.
  *
  * **Semantikk:** Kaller `window.umami.track({ url })` — Umamis native
  * pageview-API. Dette registreres som en ekte sidevisning i Umami-
@@ -30,7 +30,7 @@
  */
 
 import { useEffect, useRef } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 import { useAnalyticsContext } from './analyticsContext'
 
 /** Valgfri konfigurasjon for usePageView */

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import { createProtectedRoute } from './ProtectedRoute'
 import type { AuthContextValue } from '../auth/AuthContext'
 

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -22,7 +22,7 @@
  */
 
 import type { ReactNode } from 'react'
-import { Navigate, Outlet } from 'react-router-dom'
+import { Navigate, Outlet } from 'react-router'
 import type { AuthContextValue } from '../auth/AuthContext'
 
 /** Props for ProtectedRoute-komponenten */


### PR DESCRIPTION
Fixes #257

## Hva
Migrerer `peerDependencies`/`devDependencies` fra `react-router-dom` til `react-router` (`^7.0.0 || ^8.0.0`), og oppdaterer intern bruk (`usePageView.ts`, `ProtectedRoute.tsx`) til å importere fra `react-router`.

## Hvorfor (live-verifisert, se full analyse i issue-kommentar)
- **GHSA-qwww-vcr4-c8h2**: bekreftet fikset i react-router 8.3.0, men berører kun ustabile RSC-API-er som ingen app i porteføljen bruker — CVE-en var aldri reelt utsatt for oss.
- **Kritisk korreksjon av opprinnelig plan**: `react-router-dom` fjernes som pakke i v8 (var kun en re-export-shim). Det opprinnelig foreslåtte "widen peerDependencies til `react-router-dom: ^7.0.0 || ^8.0.0`" er derfor ugyldig — riktig pakke-nøkkel er `react-router`, som allerede er installert transitivt i alle 6 konsumentapper via `react-router-dom@7.x` (samme fysiske modul). Dette gjør endringen **ikke-brytende** for eksisterende apper, i motsetning til en hard cutover.

## Verifisert
- `npm test`: 265/265 grønne (kjørt mot ekte `react-router@8.3.0`)
- `npm run build`: ren, `dist/` fresh og committed
- `npm run lint`: ren
- QA-review: GODKJENT, empirisk verifisert (scratch-konsumentapp med kun `react-router-dom` direkte) at `react-router` resolver korrekt for konsumenter som ikke selv har `react-router` som direkte dependency ennå

## Merk (caveat fra QA)
`react-router@8.3.0` krever selv `react >=19.2.7` — strengere enn grunnmurs egne peer-range. Apper fortsatt på React 18 (biologportal, 6810, styreportal) kan derfor kun bruke `^7.0.0`-delen av rangen inntil de også oppgraderer React. Dokumentert i CHANGELOG.

## Ikke del av denne PR-en
App-migrering til faktisk react-router v8 i biologportal/6810/styreportal/smart-casual/maskemester/vinforalle håndteres av pilot-rollout-mekanismen (6810 først) som egne fremtidige issues.
