### PR TITLE
chore: remove react-router-dom from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,6 @@
 node_modules/react
 node_modules/react-dom
 node_modules/react-router
-node_modules/react-router-dom
 node_modules/@tanstack
 node_modules/.package-lock.json
 .git


### PR DESCRIPTION
Fixes #259

After migrating from react-router-dom to react-router in PR #258, the .dockerignore rule for node_modules/react-router-dom is no longer necessary. This commit cleans it up.