### PR TITLE
Fix #261: regresjonsvern mot drift mellom CLAUDE.md og .dockerignore

### DIFF
--- a/src/config/__tests__/dockerignore-docs.test.ts
+++ b/src/config/__tests__/dockerignore-docs.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const ROOT = resolve(__dirname, '..', '..', '..')
+
+/**
+ * Henter alle `node_modules/`-regler fra .dockerignore (kommentarer og
+ * tomme linjer filtreres bort).
+ */
+function dockerignoreNodeModulesRules(): string[] {
+  const content = readFileSync(resolve(ROOT, '.dockerignore'), 'utf-8')
+  return content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('node_modules/'))
+}
+
+/**
+ * Henter linjene i den fenced kodeblokken CLAUDE.md bruker for å dokumentere
+ * innholdet i .dockerignore (første kodeblokk etter `.dockerignore`-seksjonen).
+ */
+function documentedNodeModulesRules(): string[] {
+  const content = readFileSync(resolve(ROOT, 'CLAUDE.md'), 'utf-8')
+  const section = content.indexOf('## Viktig: `.dockerignore`')
+  expect(section, 'CLAUDE.md mangler `.dockerignore`-seksjonen').toBeGreaterThan(-1)
+
+  const fenceStart = content.indexOf('```', section)
+  expect(fenceStart, 'Fant ingen kodeblokk i `.dockerignore`-seksjonen').toBeGreaterThan(-1)
+  const bodyStart = content.indexOf('\n', fenceStart) + 1
+  const fenceEnd = content.indexOf('```', bodyStart)
+  expect(fenceEnd, 'Kodeblokken i `.dockerignore`-seksjonen er ikke lukket').toBeGreaterThan(-1)
+
+  return content
+    .slice(bodyStart, fenceEnd)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+}
+
+describe('CLAUDE.md dokumenterer .dockerignore korrekt', () => {
+  it('dokumenterer nøyaktig de samme node_modules-reglene som .dockerignore har', () => {
+    // Sortert sammenligning: rekkefølgen i dokumentasjonen er ikke en del av kontrakten,
+    // men innholdet er. Drift i begge retninger gir rød test.
+    expect([...documentedNodeModulesRules()].sort()).toEqual([...dockerignoreNodeModulesRules()].sort())
+  })
+
+  it('dokumenterer ikke pakker som ikke lenger ekskluderes (f.eks. react-router-dom, se #257/#259)', () => {
+    const actual = dockerignoreNodeModulesRules()
+    for (const documented of documentedNodeModulesRules()) {
+      expect(actual, `CLAUDE.md dokumenterer «${documented}», men .dockerignore har ingen slik regel`).toContain(
+        documented
+      )
+    }
+  })
+
+  it('utelater ingen node_modules-regel som faktisk finnes i .dockerignore', () => {
+    const documented = documentedNodeModulesRules()
+    for (const rule of dockerignoreNodeModulesRules()) {
+      expect(documented, `.dockerignore har «${rule}», men CLAUDE.md dokumenterer den ikke`).toContain(rule)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #261

## Vurdering av review-funnet

Review-gate-funnet (MAJOR) var **reelt på tidspunktet gaten kjørte** mot PR #260 sin diff, men er **allerede rettet på `main`** av commit `3300c36` (`docs: update for issue #259`), som landet etter merge-commit `1f71ab1`. CLAUDE.md og `.dockerignore` er nå i synk:

| CLAUDE.md (linje 100–104) | `.dockerignore` |
|---|---|
| `node_modules/react` | ✅ |
| `node_modules/react-dom` | ✅ |
| `node_modules/react-router` | ✅ |
| `node_modules/@tanstack` | ✅ |
| `node_modules/.package-lock.json` | ✅ |

De gjenværende `react-router-dom`-treffene i CLAUDE.md (linje 116/118) er bevisst prosa som forklarer migreringen fra #257 — ikke drift.

## Hva denne PR-en gjør

Ingen dokumentasjonsfiks er nødvendig, men den samme driften har nå oppstått tre ganger (#257 → #259 → #261) uten at noe fanget den. Denne PR-en legger til regresjonsvernet som manglet:

`src/config/__tests__/dockerignore-docs.test.ts` parser den fenced kodeblokken i CLAUDE.md sin `.dockerignore`-seksjon og sammenligner den med de faktiske `node_modules/`-reglene i `.dockerignore`. Testen feiler ved drift i **begge** retninger, og feiler også hvis seksjonen/kodeblokken forsvinner (så den ikke stilner ut ved en heading-endring).

Plassert sammen med `config-exports.test.ts`, som allerede holder tilsvarende repo-konsistenskontrakter (f.eks. `VERSION` ↔ `package.json`).

## TDD-verifisering

- **RØD (1)**: gjeninnførte `node_modules/react-router-dom` i CLAUDE.md-blokken — nøyaktig driften review-gaten fant → 2 av 3 tester feilet med `CLAUDE.md dokumenterer «node_modules/react-router-dom», men .dockerignore har ingen slik regel`
- **RØD (2)**: la til en udokumentert regel i `.dockerignore` → feilet med motsatt melding
- **GRØNN**: begge filer tilbakestilt → full suite grønn

```
Test Files  18 passed (18)
     Tests  268 passed (268)
```

`npm run lint` rent. `npm run build` + `git diff --exit-code dist/` rent — `tsconfig.json` ekskluderer `**/*.test.ts`, så `dist/` er upåvirket.

## Merknad utenfor scope

`npm run typecheck:test` feiler på `src/test/testHelpers.ts(5,3)`: mocken mangler `downloadRequest` fra `ApiClient`-typen. Verifisert **pre-eksisterende** (feiler identisk uten denne PR-ens fil) og urelatert til #261. Ikke del av CI (`test.yml` kjører `build` + `test`, ikke `typecheck:test`). Spores i egen issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)