### PR TITLE
Fix #263: add downloadRequest mock and typecheck test step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,5 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: git diff --exit-code dist/ || (echo "dist/ er utdatert — kjør 'npm run build' og commit dist/" && exit 1)
+      - run: npm run typecheck:test
       - run: npm test

--- a/src/test/testHelpers.ts
+++ b/src/test/testHelpers.ts
@@ -6,8 +6,9 @@ export function createMockApiClient(): ApiClient {
     request: vi.fn(),
     formDataRequest: vi.fn(),
     blobRequest: vi.fn(),
+    downloadRequest: vi.fn(),
     getCsrfToken: vi.fn(() => null),
     setCsrfToken: vi.fn(),
     resetUnauthorizedFlag: vi.fn(),
-  }
+  } satisfies ApiClient
 }


### PR DESCRIPTION
Fixes #263

## Endringer
- Legg til  i mocken (src/test/testHelpers.ts)
- Legg til `satisfies ApiClient` for type-sikkerhet
- Legg til `npm run typecheck:test` i CI-pipeline (.github/workflows/test.yml)

## Verifikasjon
- `npm run typecheck:test` kjører uten feil ✓
- `npm run test` — alle 268 tester grønn ✓
- CI-pipeline inkluderer typecheck-steg

## Årsak
Mocken ble ikke oppdatert da `downloadRequest` ble lagt til i `ApiClient`-typen. CI kjørte ikke `typecheck:test` så feilen var usynlig.