### PR TITLE
docs: add unauthorizedPath to ProtectedRoute config docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ npm run lint             # ESLint
 ### ProtectedRoute
 - `loginPath`: konfigurerbar
 - `roleCheck`: valgfri callback
+- `unauthorizedPath`: redirect-sti ved feilet rollesjekk (default: loginPath)
 - `loadingComponent`: valgfri spinner
 
 ## Apper som bruker dette biblioteket


### PR DESCRIPTION
Fixes #266

**Changes:**
- Added missing `unauthorizedPath` prop to ProtectedRoute configuration section in CLAUDE.md
- Prop enables redirect to custom 'unauthorized' page on failed role check (defaults to loginPath)
- Already documented in README.md API reference — CLAUDE.md summary now complete