### PR TITLE
CI: kjør PR-checks kun via pull_request-event (fjern dobbel-trigger)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tester
 
 on:
   push:
-    branches: [main, "auto/**"]
+    branches: [main]
     paths-ignore:
       - "**.md"
       - "docs/**"


### PR DESCRIPTION
Del av porteføljesweep 2026-08-02.

**Problem:** `push: [main, auto/**]` + `pull_request: [main]` kjører samme suiter dobbelt på PR-brancher — duplikat-check-runs med samme navn på samme SHA. Én cancelled/transient feilet duplikat holder PR-en BLOCKED i stillhet selv når den andre er grønn. Observert på biologportal#1651 (cancelled pull_request-run) og vinforalle#200 (feilet push-run) — begge krevde manuell rerun for å få auto-merge løs.

**Fiks:** `push.branches` reduseres til `[main]` — PR-brancher dekkes av pull_request-eventen alene (samme modell som 6810/test-full.yml allerede bruker). Ingen endring i jobbnavn, så branch protection-kravene er uberørt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)